### PR TITLE
Macro issue with commas inside quotes fixed

### DIFF
--- a/sjasm/tables.cpp
+++ b/sjasm/tables.cpp
@@ -1151,7 +1151,23 @@ int CMacroTable::Emit(char* naam, char*& p) {
 				*n = *p; ++n; ++p;
 			}
 			++p;
-		} else {
+		} else if(*p == '"') {
+            *n = *p; ++n; ++p;
+            while(*p && *p != '"') {
+                *n = *p; ++n; ++p;
+            }
+            if(*p) {
+                *n = *p; ++n; ++p;
+            }
+		} else if(*p == '\'') {
+		    *n = *p; ++n; ++p;
+            while(*p && *p != '\'') {
+                *n = *p; ++n; ++p;
+            }
+            if(*p) {
+                *n = *p; ++n; ++p;
+            }
+        } else {
 			while (*p && *p != ',') {
 				*n = *p; ++n; ++p;
 			}


### PR DESCRIPTION
For instance, there was such bevaviour
:
	MACRO STR string
		byte string
	ENDM

	STR "Hello world!"  ; compiled OK
	STR "Hello, world!"  ; compilation error due to comma