### PR TITLE
Added support of register operands for operators HIGH and LOW

### DIFF
--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -464,8 +464,8 @@ $c     hexadecimal
 ~     ~x       complement
 +     +x       does absolutely nothing :)
 -     -x       minus
-low   low x    low 8 bits of 16 bit value
-high  high x   high 8 bits of 16 bit value
+low   low x    low 8 bits of 16 bit value or lower part of register pair
+high  high x   high 8 bits of 16 bit value or higher part of register pair
 not   not x    logical not
 
 *     x*y      multiplication

--- a/docs/documentation.xml
+++ b/docs/documentation.xml
@@ -639,8 +639,8 @@ $c     hexadecimal
 ~     ~x       complement
 +     +x       does absolutely nothing :)
 -     -x       minus
-low   low x    low 8 bits of 16 bit value
-high  high x   high 8 bits of 16 bit value
+low   low x    low 8 bits of 16 bit value or lower part of register pair
+high  high x   high 8 bits of 16 bit value or higher part of register pair
 not   not x    logical not
 
 *     x*y      multiplication

--- a/sjasm/z80.cpp
+++ b/sjasm/z80.cpp
@@ -214,6 +214,30 @@ namespace Z80 {
 	Z80Reg GetRegister(char*& p) {
 		char* pp = p;
 		SkipBlanks(p);
+		if(memcmp(p, "high ", 5) == 0 || memcmp(p, "HIGH ", 5) == 0) {
+			p += 5;
+			switch(GetRegister(p)) {
+				case Z80_AF : return Z80_A;
+				case Z80_BC : return Z80_B;
+				case Z80_DE : return Z80_D;
+				case Z80_HL : return Z80_H;
+				case Z80_IX : return Z80_IXH;
+				case Z80_IY : return Z80_IYH;
+				default : p -= 5; return Z80_UNK;
+			}
+		}
+		if(memcmp(p, "low ", 4) == 0 || memcmp(p, "LOW ", 4) == 0) {
+			p += 4;
+				switch(GetRegister(p)) {
+				case Z80_AF : return Z80_F;
+				case Z80_BC : return Z80_C;
+				case Z80_DE : return Z80_E;
+				case Z80_HL : return Z80_L;
+				case Z80_IX : return Z80_IXL;
+				case Z80_IY : return Z80_IYL;
+				default : p -= 4; return Z80_UNK;
+			}
+		}
 		switch (*(p++)) {
 		case 'a':
 			if (!islabchar(*p)) {


### PR DESCRIPTION
For example, following code will now compile:

```
MACRO CP_Z wrd
    ld a, high wrd
    or low wrd
ENDM

CP_Z hl  ; will expand to: ld a, h: or l
```