### PR TITLE
TR-DOS filename related fixes (SAVETRD, SAVEHOB)

### DIFF
--- a/sjasm/io_trd.cpp
+++ b/sjasm/io_trd.cpp
@@ -167,38 +167,6 @@ int TRD_AddFile(char* fname, char* fhobname, int start, int length, int autostar
 	}
 
 	//header of file
-/*
-	for (i = 0; i != 9; hdr[i++] = 0x20) {
-		;
-	}
-	//for (i = 0; i != 9; ++i) {
-	for (i = 0; i < 9; ++i) {
-
-		if (*(fhobname + i) == 0) {
-			break;
-		}
-		if (*(fhobname + i) != '.') {
-			hdr[i] = *(fhobname + i); continue;
-		} else if (*(fhobname + i + 1)) {
-			hdr[8] = *(fhobname + i + 1);
-		}
-		break;
-	}
-
-	if (*(fhobname + i + 2) != 0 && *(fhobname + i + 3) != 0) {
-		hdr[0x09] = *(fhobname + i + 2);
-		hdr[0x0a] = *(fhobname + i + 3);
-	} else {
-		if (hdr[8] == 'B') {
-			hdr[0x09] = (unsigned char)(length & 0xff);
-			hdr[0x0a] = (unsigned char)(length >> 8);
-		} else {
-			hdr[0x09] = (unsigned char)(start & 0xff);
-			hdr[0x0a] = (unsigned char)(start >> 8);
-		}
-}
-*/
-
 	memset(hdr,' ',9);
 	i = strlen(fhobname);
 	if (i > 1)
@@ -207,8 +175,7 @@ int TRD_AddFile(char* fname, char* fhobname, int start, int length, int autostar
 		if (ext && ext[1])
 		{
 			hdr[8] = ext[1];
-			*ext = '\0';
-			i = strlen(fhobname);
+			i = ext-fhobname;
 		}
 	}
 	memcpy(hdr, fhobname, std::min(i,8));
@@ -220,7 +187,6 @@ int TRD_AddFile(char* fname, char* fhobname, int start, int length, int autostar
 		hdr[0x09] = (unsigned char)(start & 0xff);
 		hdr[0x0a] = (unsigned char)(start >> 8);
 	}
-
 
 	hdr[0x0b] = (unsigned char)(length & 0xff);
 	hdr[0x0c] = (unsigned char)(length >> 8);

--- a/sjasm/io_trd.cpp
+++ b/sjasm/io_trd.cpp
@@ -200,7 +200,7 @@ int TRD_AddFile(char* fname, char* fhobname, int start, int length, int autostar
 */
 	memset(hdr,' ',9);
 	i = strlen(fhobname);
-	if (fhobname[i-2] == '.')
+	if (i > 2 && fhobname[i-2] == '.')
 	{
 		hdr[8] = fhobname[i-1];
 		i -= 2;

--- a/sjasm/io_trd.cpp
+++ b/sjasm/io_trd.cpp
@@ -167,6 +167,7 @@ int TRD_AddFile(char* fname, char* fhobname, int start, int length, int autostar
 	}
 
 	//header of file
+/*
 	for (i = 0; i != 9; hdr[i++] = 0x20) {
 		;
 	}
@@ -195,7 +196,28 @@ int TRD_AddFile(char* fname, char* fhobname, int start, int length, int autostar
 			hdr[0x09] = (unsigned char)(start & 0xff);
 			hdr[0x0a] = (unsigned char)(start >> 8);
 		}
+}
+*/
+	memset(hdr,' ',9);
+	i = strlen(fhobname);
+	if (fhobname[i-2] == '.')
+	{
+		hdr[8] = fhobname[i-1];
+		i -= 2;
 	}
+	if (i > 8) {
+			Error("TR-DOS filename too long", fhobname, IF_FIRST); return 0;
+		}
+	memcpy(hdr, fhobname, i);
+
+	if (hdr[8] == 'B')	{
+		hdr[0x09] = (unsigned char)(length & 0xff);
+		hdr[0x0a] = (unsigned char)(length >> 8);
+	} else	{
+		hdr[0x09] = (unsigned char)(start & 0xff);
+		hdr[0x0a] = (unsigned char)(start >> 8);
+	}
+
 
 	hdr[0x0b] = (unsigned char)(length & 0xff);
 	hdr[0x0c] = (unsigned char)(length >> 8);

--- a/sjasm/io_trd.cpp
+++ b/sjasm/io_trd.cpp
@@ -198,9 +198,10 @@ int TRD_AddFile(char* fname, char* fhobname, int start, int length, int autostar
 		}
 }
 */
+
 	memset(hdr,' ',9);
 	i = strlen(fhobname);
-	if (i > 2)
+	if (i > 1)
 	{
 		char *ext = strrchr(fhobname, '.');
 		if (ext && ext[1])
@@ -210,10 +211,7 @@ int TRD_AddFile(char* fname, char* fhobname, int start, int length, int autostar
 			i = strlen(fhobname);
 		}
 	}
-	if (i > 8) {
-			Error("TR-DOS filename too long", fhobname, IF_FIRST); return 0;
-		}
-	memcpy(hdr, fhobname, i);
+	memcpy(hdr, fhobname, std::min(i,8));
 
 	if (hdr[8] == 'B')	{
 		hdr[0x09] = (unsigned char)(length & 0xff);

--- a/sjasm/io_trd.cpp
+++ b/sjasm/io_trd.cpp
@@ -200,10 +200,15 @@ int TRD_AddFile(char* fname, char* fhobname, int start, int length, int autostar
 */
 	memset(hdr,' ',9);
 	i = strlen(fhobname);
-	if (i > 2 && fhobname[i-2] == '.')
+	if (i > 2)
 	{
-		hdr[8] = fhobname[i-1];
-		i -= 2;
+		char *ext = strrchr(fhobname, '.');
+		if (ext && ext[1])
+		{
+			hdr[8] = ext[1];
+			*ext = '\0';
+			i = strlen(fhobname);
+		}
 	}
 	if (i > 8) {
 			Error("TR-DOS filename too long", fhobname, IF_FIRST); return 0;

--- a/sjasm/sjio.cpp
+++ b/sjasm/sjio.cpp
@@ -1008,10 +1008,15 @@ int SaveHobeta(char* fname, char* fhobname, int start, int length) {
 
 	memset(header,' ',9);
 	i = strlen(fhobname);
-	if (i > 2 && fhobname[i-2] == '.')
+	if (i > 2)
 	{
-		header[8] = fhobname[i-1];
-		i -= 2;
+		char *ext = strrchr(fhobname, '.');
+		if (ext && ext[1])
+		{
+			header[8] = ext[1];
+			*ext = '\0';
+			i = strlen(fhobname);
+		}
 	}
 	if (i > 8) {
 			Error("TR-DOS filename too long", fhobname, IF_FIRST); return 0;

--- a/sjasm/sjio.cpp
+++ b/sjasm/sjio.cpp
@@ -960,6 +960,7 @@ int SaveBinary(char* fname, int start, int length) {
 int SaveHobeta(char* fname, char* fhobname, int start, int length) {
 	unsigned char header[0x11];
 	int i;
+/*
 	for (i = 0; i != 8; header[i++] = 0x20) {
 		;
 	}
@@ -997,6 +998,34 @@ int SaveHobeta(char* fname, char* fhobname, int start, int length) {
 			header[0x0a] = (unsigned char)(start >> 8);
 		}
 	}
+*/
+	if (length + start > 0x10000) {	// io_trd.cpp/TRD_AddFile doesn't have this..?
+		length = -1;
+	}
+	if (length <= 0) {
+		length = 0x10000 - start;
+	}
+
+	memset(header,' ',9);
+	i = strlen(fhobname);
+	if (fhobname[i-2] == '.')
+	{
+		header[8] = fhobname[i-1];
+		i -= 2;
+	}
+	if (i > 8) {
+			Error("TR-DOS filename too long", fhobname, IF_FIRST); return 0;
+		}
+	memcpy(header, fhobname, i);
+
+	if (header[8] == 'B')	{
+		header[0x09] = (unsigned char)(length & 0xff);
+		header[0x0a] = (unsigned char)(length >> 8);
+	} else	{
+		header[0x09] = (unsigned char)(start & 0xff);
+		header[0x0a] = (unsigned char)(start >> 8);
+	}
+
 
 	header[0x0b] = (unsigned char)(length & 0xff);
 	header[0x0c] = (unsigned char)(length >> 8);

--- a/sjasm/sjio.cpp
+++ b/sjasm/sjio.cpp
@@ -999,7 +999,7 @@ int SaveHobeta(char* fname, char* fhobname, int start, int length) {
 		}
 	}
 */
-	if (length + start > 0x10000) {	// io_trd.cpp/TRD_AddFile doesn't have this..?
+	if (length + start > 0x10000) {
 		length = -1;
 	}
 	if (length <= 0) {
@@ -1008,7 +1008,7 @@ int SaveHobeta(char* fname, char* fhobname, int start, int length) {
 
 	memset(header,' ',9);
 	i = strlen(fhobname);
-	if (i > 2)
+	if (i > 1)
 	{
 		char *ext = strrchr(fhobname, '.');
 		if (ext && ext[1])
@@ -1018,10 +1018,7 @@ int SaveHobeta(char* fname, char* fhobname, int start, int length) {
 			i = strlen(fhobname);
 		}
 	}
-	if (i > 8) {
-			Error("TR-DOS filename too long", fhobname, IF_FIRST); return 0;
-		}
-	memcpy(header, fhobname, i);
+	memcpy(header, fhobname, std::min(i,8));
 
 	if (header[8] == 'B')	{
 		header[0x09] = (unsigned char)(length & 0xff);

--- a/sjasm/sjio.cpp
+++ b/sjasm/sjio.cpp
@@ -1008,7 +1008,7 @@ int SaveHobeta(char* fname, char* fhobname, int start, int length) {
 
 	memset(header,' ',9);
 	i = strlen(fhobname);
-	if (fhobname[i-2] == '.')
+	if (i > 2 && fhobname[i-2] == '.')
 	{
 		header[8] = fhobname[i-1];
 		i -= 2;

--- a/sjasm/sjio.cpp
+++ b/sjasm/sjio.cpp
@@ -960,45 +960,7 @@ int SaveBinary(char* fname, int start, int length) {
 int SaveHobeta(char* fname, char* fhobname, int start, int length) {
 	unsigned char header[0x11];
 	int i;
-/*
-	for (i = 0; i != 8; header[i++] = 0x20) {
-		;
-	}
-	//for (i = 0; i != 8; ++i) {
-	for (i = 0; i < 9; ++i) {
 
-		if (*(fhobname + i) == 0) {
-			break;
-		}
-		if (*(fhobname + i) != '.') {
-			header[i] = *(fhobname + i);continue;
-		} else if (*(fhobname + i + 1)) {
-			header[8] = *(fhobname + i + 1);
-		}
-		break;
-	}
-
-
-	if (length + start > 0x10000) {
-		length = -1;
-	}
-	if (length <= 0) {
-		length = 0x10000 - start;
-	}
-
-	if (*(fhobname + i + 2) != 0 && *(fhobname + i + 3) != 0) {
-		header[0x09] = *(fhobname + i + 2);
-		header[0x0a] = *(fhobname + i + 3);
-	} else {
-		if (header[8] == 'B') {
-			header[0x09] = (unsigned char)(length & 0xff);
-			header[0x0a] = (unsigned char)(length >> 8);
-		} else {
-			header[0x09] = (unsigned char)(start & 0xff);
-			header[0x0a] = (unsigned char)(start >> 8);
-		}
-	}
-*/
 	if (length + start > 0x10000) {
 		length = -1;
 	}
@@ -1014,8 +976,7 @@ int SaveHobeta(char* fname, char* fhobname, int start, int length) {
 		if (ext && ext[1])
 		{
 			header[8] = ext[1];
-			*ext = '\0';
-			i = strlen(fhobname);
+			i = ext-fhobname;
 		}
 	}
 	memcpy(header, fhobname, std::min(i,8));

--- a/tests/sjasmplus_regressions/custom/trd.asm
+++ b/tests/sjasmplus_regressions/custom/trd.asm
@@ -1,3 +1,6 @@
+;Note: the input TR-DOS filenames in this test are incorrect, and will be currently truncated as 'label1.txt' -> 'label1.t'. Change this if needed.
+;A TR-DOS filename is max. 8 characters, with a single-character extension. http://zx-modules.de/fileformats/hobetaformat.html
+
         device zxspectrum128
         
         org #8000


### PR DESCRIPTION
This mostly concerns an old bug where dots weren't properly handled in TR-DOS filenames. Previously, sjasmplus used to assume that the first dot encountered in the TR-DOS filename is followed by an extension (1 character), so a filename like 'abc.def.C' would be truncated to 'abc' with the type 'd' in the TRD image. The fix was to change the extension test method, always checking only the second-last character in the TR-DOS filename for the dot, for filenames with length > 2. As well, it will now produce an error if the input TR-DOS filename is too long.

It was complicated by the fact that it had an additional hidden 'feature' of sorts: if two characters after the extension in the input TR-DOS filename were not zero, they were treated as an uint16 and the start address field of the file was set to this value. However, I couldn't find instances of this feature being used inside sjasmplus, and there doesn't appear to be a sensible way to use it in ASM sources either (outside of doing some obscure LUA string manipulations perhaps). Since it also prevented reliably checking TR-DOS extensions, I have removed it. Personally, I think the best course of action to add this sort of functionality is with adding a regular (optional) comma-separated parameter to the save functions.