### PR TITLE
fix z00m128/sjasmplus#52

### DIFF
--- a/sjasm/parser.cpp
+++ b/sjasm/parser.cpp
@@ -61,11 +61,11 @@ int ParseExpPrim(char*& p, aint& nval) {
 	  	nval = (aint) (MemGetByte(nval) + (MemGetByte(nval + 1) << 8));
 
 	  	return 1;
-	} else if (isdigit(*p) || (*p == '#' && isalnum(*(p + 1))) || (*p == '$' && isalnum(*(p + 1))) || *p == '%') {
+	} else if (isdigit((unsigned char) * p) || (*p == '#' && isalnum((unsigned char) * (p + 1))) || (*p == '$' && isalnum((unsigned char) * (p + 1))) || *p == '%') {
 	  	res = GetConstant(p, nval);
-	} else if (isalpha(*p) || *p == '_' || *p == '.' || *p == '@') {
+	} else if (isalpha((unsigned char) * p) || *p == '_' || *p == '.' || *p == '@') {
 	  	res = GetLabelValue(p, nval);
-	} else if (*p == '?' && (isalpha(*(p + 1)) || *(p + 1) == '_' || *(p + 1) == '.' || *(p + 1) == '@')) {
+	} else if (*p == '?' && (isalpha((unsigned char) * (p + 1)) || *(p + 1) == '_' || *(p + 1) == '.' || *(p + 1) == '@')) {
 	  	++p;
 		res = GetLabelValue(p, nval);
 	} else if (DeviceID && *p == '$' && *(p + 1) == '$') {
@@ -435,7 +435,7 @@ static bool ReplaceDefineInternal(char* lp, char* const nl) {
 			continue;
 		}
 
-		if (!isalpha(*lp) && *lp != '_') {
+		if (!isalpha((unsigned char) * lp) && *lp != '_') {
 			*rp++ = *lp++;
 			continue;
 		}
@@ -547,7 +547,7 @@ void ParseLabel() {
 	tp = temp;
 	SkipBlanks();
 	IsLabelNotFound = 0;
-	if (isdigit(*tp)) {
+	if (isdigit((unsigned char) * tp)) {
 		if (NeedEQU() || NeedDEFL()) {
 			Error("Number labels only allowed as address labels");
 			return;
@@ -770,7 +770,7 @@ void ParseStructLabel(CStructure* st) {	//FIXME Ped7g why not to reuse ParseLabe
 			 	++lp;
 			 }
 	tp = temp; SkipBlanks();
-	if (isdigit(*tp)) {
+	if (isdigit((unsigned char) * tp)) {
 		Error("[STRUCT] Number labels not allowed within structs"); return;
 	}
 	PreviousIsLabel = STRDUP(tp);

--- a/sjasm/reader.cpp
+++ b/sjasm/reader.cpp
@@ -196,8 +196,8 @@ char nidtemp[LINEMAX], *nidsubp = nidtemp;
 
 char* GetID(char*& p) {
 	char* np = nidtemp;
-	if (SkipBlanks(p) || (!isalpha(*p) && *p != '_' && *p != '.')) return NULL;
-	while (islabchar(*p)) *np++ = *p++;
+	if (SkipBlanks(p) || (!isalpha((unsigned char) * p) && *p != '_' && *p != '.')) return NULL;
+	while (islabchar((unsigned char) * p)) *np++ = *p++;
 	*np = 0;
 	return nidtemp;
 }
@@ -238,13 +238,13 @@ char* getinstr(char*& p) {
 	/*char nid[LINEMAX],*/ char* np;
 	np = instrtemp;
 	SkipBlanks(p);
-	if (!isalpha(*p) && *p != '.') {
+	if (!isalpha((unsigned char) * p) && *p != '.') {
 		return 0;
 	} else {
 		*np = *p; ++p; ++np;
 	}
 	while (*p) {
-		if (!isalnum(*p) && *p != '_') {
+		if (!isalnum((unsigned char) * p) && *p != '_') {
 			break;
 		} /////////////////////////////////////
 		*np = *p; ++p; ++np;
@@ -304,7 +304,7 @@ int need(char*& p, char c) {
 
 int needa(char*& p, const char* c1, int r1, const char* c2, int r2, const char* c3, int r3) {
 	//  SkipBlanks(p);
-	if (!isalpha(*p)) {
+	if (!isalpha((unsigned char) * p)) {
 		return 0;
 	}
 	if (cmphstr(p, c1)) {
@@ -354,10 +354,10 @@ int getval(int p) {
 	case '9':
 		return p - '0';
 	default:
-		if (isupper(p)) {
+		if (isupper((unsigned char)p)) {
 			return p - 'A' + 10;
 		}
-		if (islower(p)) {
+		if (islower((unsigned char)p)) {
 			return p - 'a' + 10;
 		}
 		return 200;
@@ -772,7 +772,7 @@ EDelimiterType GetDelimiterOfLastFileName() {
 }
 
 int islabchar(char p) {
-	if (isalnum(p) || p == '_' || p == '.' || p == '?' || p == '!' || p == '#' || p == '@') {
+	if (isalnum((unsigned char)p) || p == '_' || p == '.' || p == '?' || p == '!' || p == '#' || p == '@') {
 		return 1;
 	}
 	return 0;

--- a/sjasm/tables.cpp
+++ b/sjasm/tables.cpp
@@ -598,11 +598,11 @@ void CDefineTable::Add(const char* name, const char* value, CStringsList* nss) {
 	if (FindDuplicate(name)) {
 		Error("Duplicate define", name);
 	}
-	defs[((unsigned char)*name)&127] = new CDefineTableEntry(name, value, nss, defs[((unsigned char)*name)&127]);
+	defs[(*name)&127] = new CDefineTableEntry(name, value, nss, defs[(*name)&127]);
 }
 
 char* CDefineTable::Get(const char* name) {
-	CDefineTableEntry* p = defs[((unsigned char)*name)&127];
+	CDefineTableEntry* p = defs[(*name)&127];
 	while (p) {
 		if (!strcmp(name, p->name)) {
 			DefArrayList = p->nss;
@@ -615,7 +615,7 @@ char* CDefineTable::Get(const char* name) {
 }
 
 int CDefineTable::FindDuplicate(const char* name) {
-	CDefineTableEntry* p = defs[((unsigned char)*name)&127];
+	CDefineTableEntry* p = defs[(*name)&127];
 	while (p) {
 		if (!strcmp(name, p->name)) {
 			return 1;
@@ -626,7 +626,7 @@ int CDefineTable::FindDuplicate(const char* name) {
 }
 
 int CDefineTable::Replace(const char* name, const char* value) {
-	CDefineTableEntry* p = defs[((unsigned char)*name)&127];
+	CDefineTableEntry* p = defs[(*name)&127];
 	while (p) {
 		if (!strcmp(name, p->name)) {
 			delete[](p->value);
@@ -636,7 +636,7 @@ int CDefineTable::Replace(const char* name, const char* value) {
 		}
 		p = p->next;
 	}
-	defs[((unsigned char)*name)&127] = new CDefineTableEntry(name, value, 0, defs[((unsigned char)*name)&127]);
+	defs[(*name)&127] = new CDefineTableEntry(name, value, 0, defs[(*name)&127]);
 	return 1;
 }
 
@@ -647,12 +647,12 @@ int CDefineTable::Replace(const char* name, const int value) {
 }
 
 int CDefineTable::Remove(const char* name) {
-	CDefineTableEntry* p = defs[((unsigned char)*name)&127];
+	CDefineTableEntry* p = defs[(*name)&127];
 	CDefineTableEntry* p2 = NULL;
 	while (p) {
 		if (!strcmp(name, p->name)) {
 			// unchain the particular item
-			if (NULL == p2) defs[((unsigned char)*name)&127] = p->next;
+			if (NULL == p2) defs[(*name)&127] = p->next;
 			else			p2->next = p->next;
 			p->next = NULL;
 			// delete it
@@ -696,7 +696,7 @@ void CMacroDefineTable::setdefs(CDefineTableEntry* ndefs) {
 
 char* CMacroDefineTable::getverv(char* name) {
 	CDefineTableEntry* p = defs;
-	if (!used[((unsigned char)*name)&127]) return NULL;
+	if (!used[(*name)&127]) return NULL;
 	while (p) {
 		if (!strcmp(name, p->name)) return p->value;
 		p = p->next;
@@ -706,7 +706,7 @@ char* CMacroDefineTable::getverv(char* name) {
 
 int CMacroDefineTable::FindDuplicate(char* name) {
 	CDefineTableEntry* p = defs;
-	if (!used[((unsigned char)*name)&127]) {
+	if (!used[(*name)&127]) {
 		return 0;
 	}
 	while (p) {
@@ -759,7 +759,7 @@ void CMacroTable::Add(char* nnaam, char*& p) {
 		Error("No enough memory!", NULL, FATAL);
 	}
 	macs = new CMacroTableEntry(macroname, macs);
-	used[((unsigned char)*macroname)&127] = 1;
+	used[(*macroname)&127] = 1;
 	SkipBlanks(p);
 	while (*p) {
 		if (!(n = GetID(p))) {
@@ -788,7 +788,7 @@ void CMacroTable::Add(char* nnaam, char*& p) {
 
 int CMacroTable::Emit(char* naam, char*& p) {
 	// search for the desired macro
-	if (!used[((unsigned char)*naam)&127]) return 0;
+	if (!used[(*naam)&127]) return 0;
 	CMacroTableEntry* m = macs;
 	while (m && strcmp(naam, m->naam)) m = m->next;
 	if (!m) return 0;
@@ -1108,11 +1108,11 @@ CStructure* CStructureTable::Add(char* naam, int no, int idx, int gl) {
 	if (FindDuplicate(sp)) {
 		Error("Duplicate structure name", naam, EARLY);
 	}
-	strs[((unsigned char)*sp)&127] = new CStructure(naam, sp, idx, 0, gl, strs[((unsigned char)*sp)&127]);
+	strs[(*sp)&127] = new CStructure(naam, sp, idx, 0, gl, strs[(*sp)&127]);
 	if (no) {
-		strs[((unsigned char)*sp)&127]->AddMember(new CStructureEntry2(0, no, -1, SMEMBBLOCK));
+		strs[(*sp)&127]->AddMember(new CStructureEntry2(0, no, -1, SMEMBBLOCK));
 	}
-	return strs[((unsigned char)*sp)&127];
+	return strs[(*sp)&127];
 }
 
 CStructure* CStructureTable::zoek(const char* naam, int gl) {
@@ -1124,13 +1124,13 @@ CStructure* CStructureTable::zoek(const char* naam, int gl) {
 	}
 	STRCAT(sn, LINEMAX, naam);
 	sp = sn;
-	CStructure* p = strs[((unsigned char)*sp)&127];
+	CStructure* p = strs[(*sp)&127];
 	while (p) {
 		if (!strcmp(sp, p->id)) return p;
 		p = p->next;
 	}
 	if (gl || !ModuleName) return NULL;
-	sp += 1 + strlen(ModuleName); p = strs[((unsigned char)*sp)&127];
+	sp += 1 + strlen(ModuleName); p = strs[(*sp)&127];
 	while (p) {
 		if (!strcmp(sp, p->id)) return p;
 		p = p->next;

--- a/sjasm/tables.cpp
+++ b/sjasm/tables.cpp
@@ -51,13 +51,13 @@ char* ValidateLabel(char* naam, int flags) {
 		break;
 	}
 	naam = np;
-	if (!isalpha(*np) && *np != '_') {
+	if (!isalpha((unsigned char) * np) && *np != '_') {
 		Error("Invalid labelname", naam);
 		delete[] label;
 		return NULL;
 	}
 	while (*np) {
-		if (isalnum(*np) || *np == '_' || *np == '.' || *np == '?' || *np == '!' || *np == '#' || *np == '@') {
+		if (isalnum((unsigned char) * np) || *np == '_' || *np == '.' || *np == '?' || *np == '!' || *np == '#' || *np == '@') {
 			++np;
 		} else {
 			Error("Invalid labelname", naam);
@@ -107,7 +107,7 @@ int GetLabelValue(char*& p, aint& val) {
 		STRCAT(temp, LINEMAX, ">");
 		len = strlen(temp);
 		np = temp + len;
-		if (!isalpha(*p) && *p != '_') {
+		if (!isalpha((unsigned char) * p) && *p != '_') {
 			Error("Invalid labelname", temp);
 			return 0;
 		}
@@ -153,7 +153,7 @@ int GetLabelValue(char*& p, aint& val) {
 		STRCAT(temp, LINEMAX, ".");
 	}
 	len = strlen(temp); np = temp + len;
-	if (!isalpha(*p) && *p != '_') {
+	if (!isalpha((unsigned char) *p) && *p != '_') {
 		Error("Invalid labelname", temp); return 0;
 	}
 	while (islabchar(*p)) *np++ = *p++;
@@ -598,11 +598,11 @@ void CDefineTable::Add(const char* name, const char* value, CStringsList* nss) {
 	if (FindDuplicate(name)) {
 		Error("Duplicate define", name);
 	}
-	defs[(*name)&127] = new CDefineTableEntry(name, value, nss, defs[(*name)&127]);
+	defs[((unsigned char)*name)&127] = new CDefineTableEntry(name, value, nss, defs[((unsigned char)*name)&127]);
 }
 
 char* CDefineTable::Get(const char* name) {
-	CDefineTableEntry* p = defs[(*name)&127];
+	CDefineTableEntry* p = defs[((unsigned char)*name)&127];
 	while (p) {
 		if (!strcmp(name, p->name)) {
 			DefArrayList = p->nss;
@@ -615,7 +615,7 @@ char* CDefineTable::Get(const char* name) {
 }
 
 int CDefineTable::FindDuplicate(const char* name) {
-	CDefineTableEntry* p = defs[(*name)&127];
+	CDefineTableEntry* p = defs[((unsigned char)*name)&127];
 	while (p) {
 		if (!strcmp(name, p->name)) {
 			return 1;
@@ -626,7 +626,7 @@ int CDefineTable::FindDuplicate(const char* name) {
 }
 
 int CDefineTable::Replace(const char* name, const char* value) {
-	CDefineTableEntry* p = defs[(*name)&127];
+	CDefineTableEntry* p = defs[((unsigned char)*name)&127];
 	while (p) {
 		if (!strcmp(name, p->name)) {
 			delete[](p->value);
@@ -636,7 +636,7 @@ int CDefineTable::Replace(const char* name, const char* value) {
 		}
 		p = p->next;
 	}
-	defs[(*name)&127] = new CDefineTableEntry(name, value, 0, defs[(*name)&127]);
+	defs[((unsigned char)*name)&127] = new CDefineTableEntry(name, value, 0, defs[((unsigned char)*name)&127]);
 	return 1;
 }
 
@@ -647,12 +647,12 @@ int CDefineTable::Replace(const char* name, const int value) {
 }
 
 int CDefineTable::Remove(const char* name) {
-	CDefineTableEntry* p = defs[(*name)&127];
+	CDefineTableEntry* p = defs[((unsigned char)*name)&127];
 	CDefineTableEntry* p2 = NULL;
 	while (p) {
 		if (!strcmp(name, p->name)) {
 			// unchain the particular item
-			if (NULL == p2) defs[(*name)&127] = p->next;
+			if (NULL == p2) defs[((unsigned char)*name)&127] = p->next;
 			else			p2->next = p->next;
 			p->next = NULL;
 			// delete it
@@ -696,7 +696,7 @@ void CMacroDefineTable::setdefs(CDefineTableEntry* ndefs) {
 
 char* CMacroDefineTable::getverv(char* name) {
 	CDefineTableEntry* p = defs;
-	if (!used[(*name)&127]) return NULL;
+	if (!used[((unsigned char)*name)&127]) return NULL;
 	while (p) {
 		if (!strcmp(name, p->name)) return p->value;
 		p = p->next;
@@ -706,7 +706,7 @@ char* CMacroDefineTable::getverv(char* name) {
 
 int CMacroDefineTable::FindDuplicate(char* name) {
 	CDefineTableEntry* p = defs;
-	if (!used[(*name)&127]) {
+	if (!used[((unsigned char)*name)&127]) {
 		return 0;
 	}
 	while (p) {
@@ -759,7 +759,7 @@ void CMacroTable::Add(char* nnaam, char*& p) {
 		Error("No enough memory!", NULL, FATAL);
 	}
 	macs = new CMacroTableEntry(macroname, macs);
-	used[(*macroname)&127] = 1;
+	used[((unsigned char)*macroname)&127] = 1;
 	SkipBlanks(p);
 	while (*p) {
 		if (!(n = GetID(p))) {
@@ -788,7 +788,7 @@ void CMacroTable::Add(char* nnaam, char*& p) {
 
 int CMacroTable::Emit(char* naam, char*& p) {
 	// search for the desired macro
-	if (!used[(*naam)&127]) return 0;
+	if (!used[((unsigned char)*naam)&127]) return 0;
 	CMacroTableEntry* m = macs;
 	while (m && strcmp(naam, m->naam)) m = m->next;
 	if (!m) return 0;
@@ -1108,11 +1108,11 @@ CStructure* CStructureTable::Add(char* naam, int no, int idx, int gl) {
 	if (FindDuplicate(sp)) {
 		Error("Duplicate structure name", naam, EARLY);
 	}
-	strs[(*sp)&127] = new CStructure(naam, sp, idx, 0, gl, strs[(*sp)&127]);
+	strs[((unsigned char)*sp)&127] = new CStructure(naam, sp, idx, 0, gl, strs[((unsigned char)*sp)&127]);
 	if (no) {
-		strs[(*sp)&127]->AddMember(new CStructureEntry2(0, no, -1, SMEMBBLOCK));
+		strs[((unsigned char)*sp)&127]->AddMember(new CStructureEntry2(0, no, -1, SMEMBBLOCK));
 	}
-	return strs[(*sp)&127];
+	return strs[((unsigned char)*sp)&127];
 }
 
 CStructure* CStructureTable::zoek(const char* naam, int gl) {
@@ -1124,13 +1124,13 @@ CStructure* CStructureTable::zoek(const char* naam, int gl) {
 	}
 	STRCAT(sn, LINEMAX, naam);
 	sp = sn;
-	CStructure* p = strs[(*sp)&127];
+	CStructure* p = strs[((unsigned char)*sp)&127];
 	while (p) {
 		if (!strcmp(sp, p->id)) return p;
 		p = p->next;
 	}
 	if (gl || !ModuleName) return NULL;
-	sp += 1 + strlen(ModuleName); p = strs[(*sp)&127];
+	sp += 1 + strlen(ModuleName); p = strs[((unsigned char)*sp)&127];
 	while (p) {
 		if (!strcmp(sp, p->id)) return p;
 		p = p->next;


### PR DESCRIPTION
Reverted to using (unsigned char)*p conversions to fix characters above 127 on Windows. I only changed it back in the old bits of code, so there might be other situations where this becomes problematic. But at least it fixes `tests/sjasmplus_regressions/wrong_index_offset.asm` for me.