### PR TITLE
Fixed memory leak and line numbers in _lua_showerror()

### DIFF
--- a/sjasm/directives.cpp
+++ b/sjasm/directives.cpp
@@ -1801,21 +1801,21 @@ void _lua_showerror() {
 	int ln;
 
 	// part from Error(...)
-	char *err = STRDUP(lua_tostring(LUA, -1));
+	char *err = STRDUP(lua_tostring(LUA, -1)), *lnp = err;
 	if (err == NULL) {
 		Error("No enough memory!", NULL, FATAL);
 	}
-	err += 18;
-	char *pos = strstr(err, ":");
-	*(pos++) = 0;
-	ln = atoi(err) + LuaLine;
+	while (*lnp != ':' || !isdigit((unsigned char) *(lnp+1))) lnp++;
+	char *msgp = strchr(++lnp, ':');
+	*(msgp++) = '\0';
+	ln = atoi(lnp) + LuaLine;
 
 	// print error and other actions
-	err = ErrorLine;
-	SPRINTF3(err, LINEMAX2, "%s(%d): error: [LUA]%s", filename, ln, pos);
+	SPRINTF3(ErrorLine, LINEMAX2, "%s(%d): error: [LUA]%s", filename, ln, msgp);
+	free(err);
 
-	if (!strchr(err, '\n')) {
-		STRCAT(err, LINEMAX2, "\n");
+	if (!strchr(ErrorLine, '\n')) {
+		STRCAT(ErrorLine, LINEMAX2, "\n");
 	}
 
 	if (GetListingFile()) fputs(ErrorLine, GetListingFile());


### PR DESCRIPTION
I found a couple of problems in _lua_showerror(), hopefully it is now better. See commit for more information.

If someone has those LUA hard crashes on error messages going on with an older version (e.g. stable 1.12.0), see if this fixes it perhaps, because I can't reproduce it at the moment.