### PR TITLE
CirrusCI: build tasks depending on encrypted envvars only if repo owner is z00m

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,7 +29,7 @@ pipe:
     # makefile variables affecting build options
     DEBUG: 1
     COVERALLS_SERVICE: 1
-  only_if: $COVERALLS_REPO_TOKEN != ''
+  only_if: \"$COVERALLS_REPO_TOKEN\" != ''
   resources:
     cpu: 3
     memory: 1G

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,8 @@ pipe:
     # makefile variables affecting build options
     DEBUG: 1
     COVERALLS_SERVICE: 1
-  only_if: !( $COVERALLS_REPO_TOKEN =~ ENCRYPTED.* )
+  # avoid building "master" in repositories where default branch is different
+  only_if: $CIRRUS_BRANCH != 'master' || $CIRRUS_DEFAULT_BRANCH == 'master'
   resources:
     cpu: 3
     memory: 1G

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,13 +30,13 @@ pipe:
     # makefile variables affecting build options
     DEBUG: 1
     COVERALLS_SERVICE: 1
-  only_if: \"$COVERALLS_REPO_TOKEN\" != ''
+  only_if: \"$COVERALLS_REPO_TOKEN\" !=~ 'ENCRYPTED.*'
   resources:
     cpu: 3
     memory: 1G
   steps:
     - image: gcc:7
-      generate_gcov_script: echo "$COVERALLS_REPO_TOKEN" || make clean && make -j3 coverage
+      generate_gcov_script: make clean && make -j3 coverage
     - image: python:3.7
       # installing my patched version of "cpp-coveralls" to get support for CI_SERVICE_NAME and git-revision number
       install_coveralls_plugin_script: pip install git+https://github.com/ped7g/cpp-coveralls.git@master

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ pipe:
     # makefile variables affecting build options
     DEBUG: 1
     COVERALLS_SERVICE: 1
-  only_if: ! $COVERALLS_REPO_TOKEN =~ ENCRYPTED.*
+  only_if: !( $COVERALLS_REPO_TOKEN =~ ENCRYPTED.* )
   resources:
     cpu: 3
     memory: 1G

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,6 +29,7 @@ pipe:
     # makefile variables affecting build options
     DEBUG: 1
     COVERALLS_SERVICE: 1
+  only_if: $COVERALLS_REPO_TOKEN != ''
   resources:
     cpu: 3
     memory: 1G

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,4 @@
 makefile_build_task:
-  only_if: 0
   env:
     CIRRUS_CLONE_DEPTH: 1
   container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,6 +19,8 @@ makefile_build_task:
 
 pipe:
   name: coveralls.io coverage report
+  # check if this is z00m's repository (the encrypted token belongs to original repo)
+  only_if: $CIRRUS_REPO_OWNER == 'z00m128'
   #depends_on: makefile_build  ## saves some resources in case regular build fails, but that's rare
   env:
     # needs full clone to calculate revision number from git
@@ -29,8 +31,6 @@ pipe:
     # makefile variables affecting build options
     DEBUG: 1
     COVERALLS_SERVICE: 1
-  # avoid building "master" in repositories where default branch is different
-  only_if: $CIRRUS_BRANCH != 'master' || $CIRRUS_DEFAULT_BRANCH == 'master'
   resources:
     cpu: 3
     memory: 1G

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ pipe:
     # makefile variables affecting build options
     DEBUG: 1
     COVERALLS_SERVICE: 1
-  only_if: $COVERALLS_REPO_TOKEN !=~ 'ENCRYPTED.*'
+  only_if: ! $COVERALLS_REPO_TOKEN =~ ENCRYPTED.*
   resources:
     cpu: 3
     memory: 1G

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ pipe:
     # makefile variables affecting build options
     DEBUG: 1
     COVERALLS_SERVICE: 1
-  only_if: \"$COVERALLS_REPO_TOKEN\" !=~ 'ENCRYPTED.*'
+  only_if: $COVERALLS_REPO_TOKEN !=~ 'ENCRYPTED.*'
   resources:
     cpu: 3
     memory: 1G

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,5 @@
 makefile_build_task:
+  only_if: 0
   env:
     CIRRUS_CLONE_DEPTH: 1
   container:
@@ -35,7 +36,7 @@ pipe:
     memory: 1G
   steps:
     - image: gcc:7
-      generate_gcov_script: make clean && make -j3 coverage
+      generate_gcov_script: echo "$COVERALLS_REPO_TOKEN" || make clean && make -j3 coverage
     - image: python:3.7
       # installing my patched version of "cpp-coveralls" to get support for CI_SERVICE_NAME and git-revision number
       install_coveralls_plugin_script: pip install git+https://github.com/ped7g/cpp-coveralls.git@master


### PR DESCRIPTION
To prevent useless building in fork repositories, when somebody has Cirrus CI enabled also for the forked one, but then the encrypted variables fail to decrypt (the owner of forked repo must provide his own sensitive values like tokens/etc and edit the test with his owner name, to make all tasks run in his forked repo).