### PR TITLE
CirrusCI: FreeBSD build configuration, bash shebang modified

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,3 +77,29 @@ task:
   # try to run tests, but ignore the end result (some tests are expected to fail)
   # (needs manual review from time to time, if the failures are as expected)
   #assemble_tests_script: ContinuousIntegration\winbuild_mingw32_tests.bat 1
+
+task:
+  name: FreeBSD clang-6 build
+  env:
+    CIRRUS_CLONE_DEPTH: 1
+  freebsd_instance:
+    image: freebsd-12-0-release-amd64
+    cpu: 4
+    memory: 4G
+  # lock pkg on current version (sjasmplus does not care as long as it can install ...)
+  # install git (lite), GNU make and bash
+  # (FreeBSD make can't handle current Makefile, git is needed for UnitTest++ submodule)
+  sw_install_script: pkg lock -y pkg && pkg install -y git-lite gmake bash
+  #sw_versions2_script:
+    #- git --version || echo "no git"
+    #- bash --version || echo "no bash"
+    #- gmake --version || echo "no gmake"
+    #- cc --version || echo "no cc"
+    #- c++ --version || echo "no c++"
+  submodules_script:
+    - git submodule init
+    - git submodule update
+  # regular binary build (will be not run, just testing the build process)
+  build_script: gmake clean && gmake -j4 CC=cc CXX=c++
+  # build+test the unit test binary
+  test_script: gmake clean && gmake -j4 CC=cc CXX=c++ tests

--- a/ContinuousIntegration/build_tests_in_place.sh
+++ b/ContinuousIntegration/build_tests_in_place.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo -e "\033[91mThis script will try to build all tests 'in place' => may and will overwrite files used to verify test results."
 echo -e "\033[93mTo just run the tests use the \"runner\" script '\033[96mtest_folder_tests.sh\033[93m'.\n\033[96m"

--- a/ContinuousIntegration/common_fn.sh
+++ b/ContinuousIntegration/common_fn.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # $1 = EXE_NAME, $2 = PROJECT_DIR, result is set into global $EXE
 function find_newest_binary() {

--- a/ContinuousIntegration/test_folder_examples.sh
+++ b/ContinuousIntegration/test_folder_examples.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## script init + helper functions
 PROJECT_DIR=$PWD

--- a/ContinuousIntegration/test_folder_tests.sh
+++ b/ContinuousIntegration/test_folder_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## script init + helper functions
 HELP_STRING="Run the script from \033[96mproject root\033[0m directory."

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 # set up CC+CXX explicitly, because windows MinGW/MSYS environment don't have it set up
 CC=gcc
 CXX=g++
-BASH=/bin/bash
+BASH=/usr/bin/env bash
 
 PREFIX=/usr/local
 INSTALL=install -c

--- a/sjasm/support.h
+++ b/sjasm/support.h
@@ -50,6 +50,9 @@ extern const char pathGoodSlash;
 #else
 
 #include <sys/time.h>
+#if !defined(__MINGW32__)
+#include <sys/wait.h>
+#endif
 #include <unistd.h>
 
 #ifndef TCHAR


### PR DESCRIPTION
* bash is now shebanged through `/usr/bin/env bash` (`/bin/bash` fails
on FreeBSD)
* On POSIX systems the `<sys/wait.h>` include is added for
`WEXITSTATUS(..)` definition (FreeBSD needs it from here, MinGW doesn't
have this include at all, linux defines `WEXITSTATUS` in previously used
includes)
* FreeBSD build configuration for Cirrus-CI, it has the clang-6.0
compiler available by default