### PR TITLE
Fix issue108 - absolute paths with MS windows drive letters

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -80,7 +80,7 @@ task:
   env:
     CIRRUS_CLONE_DEPTH: 1
   freebsd_instance:
-    image_family: freebsd-13-0-snap
+    image: freebsd-13-0-current-amd64-v20200220
     cpu: 2
     memory: 3G
   ## lock pkg on current version (sjasmplus does not care as long as it can install ...)

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -80,7 +80,7 @@ task:
   env:
     CIRRUS_CLONE_DEPTH: 1
   freebsd_instance:
-    image: freebsd-13-0-current-amd64-v20200220
+    image_family: freebsd-13-0-snap
     cpu: 2
     memory: 3G
   ## lock pkg on current version (sjasmplus does not care as long as it can install ...)
@@ -88,7 +88,7 @@ task:
   ## - locking disabled after second incident recommending "Consider running 'pkg update -f'"
   # install git (lite), GNU make and bash
   # (FreeBSD make can't handle current Makefile, git is needed for UnitTest++ submodule)
-  sw_install_script: pkg update -f && pkg install -y git-lite gmake bash diffutils
+  sw_install_script: IGNORE_OSVERSION=yes pkg update -f && pkg install -y git-lite gmake bash diffutils
   sw_versions2_script:
     - git --version || echo "no git"
     - bash --version || echo "no bash"

--- a/sjasm/sjio.cpp
+++ b/sjasm/sjio.cpp
@@ -557,6 +557,12 @@ static void OpenDefaultList(const char *fullpath);
 static stdin_log_t::const_iterator stdin_read_it;
 static stdin_log_t* stdin_log = nullptr;
 
+FILE* dbg_fopen(const char* fname, const char* modes) {
+	FILE* f = fopen(fname, modes);
+	printf("fopen = %p modes [%s]\tname (%lu) [%s]\n", (void*)f, modes, strlen(fname), fname);
+	return f;
+}
+
 void OpenFile(const char* nfilename, bool systemPathsBeforeCurrent, stdin_log_t* fStdinLog)
 {
 	const char* oFileNameFull = fileNameFull;

--- a/sjasm/sjio.cpp
+++ b/sjasm/sjio.cpp
@@ -561,7 +561,7 @@ void OpenFile(const char* nfilename, bool systemPathsBeforeCurrent, stdin_log_t*
 {
 	const char* oFileNameFull = fileNameFull;
 	TextFilePos oSourcePos = CurSourcePos;
-	char* oCurrentDirectory, * fullpath, * listFullName = NULL;
+	char* oCurrentDirectory, * fullpath;
 	TCHAR* filenamebegin;
 
 	if (++IncludeLevel > 20) {
@@ -597,9 +597,8 @@ void OpenFile(const char* nfilename, bool systemPathsBeforeCurrent, stdin_log_t*
 	// show in listing file which file was opened
 	FILE* listFile = GetListingFile();
 	if (LASTPASS == pass && listFile) {
-		listFullName = STRDUP(fullpath);	// create copy of full filename for listing file
 		fputs("# file opened: ", listFile);
-		fputs(listFullName, listFile);
+		fputs(fileNameFull, listFile);
 		fputs("\n", listFile);
 	}
 
@@ -625,9 +624,8 @@ void OpenFile(const char* nfilename, bool systemPathsBeforeCurrent, stdin_log_t*
 	// show in listing file which file was closed
 	if (LASTPASS == pass && listFile) {
 		fputs("# file closed: ", listFile);
-		fputs(listFullName, listFile);
+		fputs(fileNameFull, listFile);
 		fputs("\n", listFile);
-		free(listFullName);
 
 		// close listing file (if "default" listing filename is used)
 		if (FP_ListingFile && 0 == IncludeLevel && Options::IsDefaultListingName) {

--- a/sjasm/sjio.cpp
+++ b/sjasm/sjio.cpp
@@ -557,12 +557,6 @@ static void OpenDefaultList(const char *fullpath);
 static stdin_log_t::const_iterator stdin_read_it;
 static stdin_log_t* stdin_log = nullptr;
 
-FILE* dbg_fopen(const char* fname, const char* modes) {
-	FILE* f = fopen(fname, modes);
-	printf("fopen = %p modes [%s]\tname (%lu) [%s]\n", (void*)f, modes, strlen(fname), fname);
-	return f;
-}
-
 void OpenFile(const char* nfilename, bool systemPathsBeforeCurrent, stdin_log_t* fStdinLog)
 {
 	const char* oFileNameFull = fileNameFull;
@@ -582,7 +576,7 @@ void OpenFile(const char* nfilename, bool systemPathsBeforeCurrent, stdin_log_t*
 	} else {
 		fullpath = GetPath(nfilename, &filenamebegin, systemPathsBeforeCurrent);
 
-		if (!FOPEN_ISOK(FP_Input, fullpath, "rb")) {
+		if (!*fullpath || !FOPEN_ISOK(FP_Input, fullpath, "rb")) {
 			free(fullpath);
 			Error("Error opening file", nfilename, FATAL);
 		}

--- a/sjasm/support.h
+++ b/sjasm/support.h
@@ -61,7 +61,7 @@ int SJ_SearchPath(const char* oudzp, const char* filename, const char* /*extensi
 FILE* dbg_fopen(const char* fname, const char* modes);
 
 #define FOPEN(pFile, filename, mode) (pFile = fopen(filename, mode))
-#define FOPEN_ISOK(pFile, filename, mode) ((pFile = dbg_fopen(filename, mode)) != NULL)
+#define FOPEN_ISOK(pFile, filename, mode) ((pFile = fopen(filename, mode)) != NULL)
 
 #define STRDUP strdup
 #define STRCAT(strDestination, sizeInBytes, strSource) strncat(strDestination, strSource, sizeInBytes)

--- a/sjasm/support.h
+++ b/sjasm/support.h
@@ -58,8 +58,10 @@ long GetTickCount();
 void SJ_GetCurrentDirectory(int, char*);
 int SJ_SearchPath(const char* oudzp, const char* filename, const char* /*extension*/, int maxlen, char* nieuwzp, char** ach);
 
+FILE* dbg_fopen(const char* fname, const char* modes);
+
 #define FOPEN(pFile, filename, mode) (pFile = fopen(filename, mode))
-#define FOPEN_ISOK(pFile, filename, mode) ((pFile = fopen(filename, mode)) != NULL)
+#define FOPEN_ISOK(pFile, filename, mode) ((pFile = dbg_fopen(filename, mode)) != NULL)
 
 #define STRDUP strdup
 #define STRCAT(strDestination, sizeInBytes, strSource) strncat(strDestination, strSource, sizeInBytes)


### PR DESCRIPTION
May break linux usage if somebody has filename like `'e:/myfile.asm'` ... in such case I can just ask you one thing... are you serious?