### PR TITLE
Added option to generate virtual address labels, not physical address, in the labels list emitted by LABELSLIST

### DIFF
--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -306,6 +306,7 @@
   -D&lt;NAME&gt;[=&lt;value&gt;]       Define &lt;NAME&gt; as &lt;value&gt;
   -                        Reads STDIN as source (even in between regular files)
   --longptr                No device: program counter $ can go beyond 0x10000
+  --virtlabels             Emit virtual intead of physical address labels in LABELSLIST
   --reversepop             Enable reverse POP order (as in base SjASM version)
   --dirbol                 Enable directives processing from the beginning of line
   --nofakes                Disable fake instructions (obsolete, use --syntax=F)

--- a/docs/documentation.xml
+++ b/docs/documentation.xml
@@ -438,6 +438,7 @@
   -D&lt;NAME&gt;[=&lt;value&gt;]       Define &lt;NAME&gt; as &lt;value&gt;
   -                        Reads STDIN as source (even in between regular files)
   --longptr                No device: program counter $ can go beyond 0x10000
+  --virtlabels             Emit virtual intead of physical address labels in LABELSLIST
   --reversepop             Enable reverse POP order (as in base SjASM version)
   --dirbol                 Enable directives processing from the beginning of line
   --nofakes                Disable fake instructions (obsolete, use --syntax=F)

--- a/sjasm/sjasm.cpp
+++ b/sjasm/sjasm.cpp
@@ -72,6 +72,7 @@ void PrintHelp() {
 	_COUT "  -D<NAME>[=<value>]       Define <NAME> as <value>" _ENDL;
 	_COUT "  -                        Reads STDIN as source (even in between regular files)" _ENDL;
 	_COUT "  --longptr                No device: program counter $ can go beyond 0x10000" _ENDL;
+	_COUT "  --virtlabels             Emit virtual intead of physical address labels in LABELSLIST" _ENDL;
 	_COUT "  --reversepop             Enable reverse POP order (as in base SjASM version)" _ENDL;
 	_COUT "  --dirbol                 Enable directives from the beginning of line" _ENDL;
 	_COUT "  --nofakes                Disable fake instructions" _ENDL;
@@ -108,6 +109,8 @@ namespace Options {
 	bool IsI8080 = false;
 	bool IsLR35902 = false;
 	bool IsLongPtr = false;
+
+	bool EmitVirtualLabels = false;
 
 	// Include directories list is initialized with "." directory
 	CStringsList* IncludeDirsList = new CStringsList(".");
@@ -452,6 +455,8 @@ namespace Options {
 					AddLabelListing = true;
 				} else if (!strcmp(opt, "longptr")) {
 					IsLongPtr = true;
+				} else if (!strcmp(opt,"virtlabels")) {
+					EmitVirtualLabels = true;
 				} else if (CheckAssignmentOption("msg", NULL, 0)) {
 					if (!strcmp("none", val)) {
 						OutputVerbosity = OV_NONE;

--- a/sjasm/sjasm.h
+++ b/sjasm/sjasm.h
@@ -86,6 +86,10 @@ namespace Options {
 	extern bool IsLR35902;			// "Sharp LR35902" CPU mode (must be set at CLI, blocks others)
 	extern bool IsLongPtr;
 
+	extern bool EmitVirtualLabels; // emit virtual labels in LABELSLIST, that tied to Z80 address space,
+	                               // not to physical address (PG:ADDR). Format is ":ADDR label", staring
+	                               // from colon, then 16bit address, then label.
+
 	extern CStringsList* IncludeDirsList;
 	extern CDefineTable CmdDefineTable;
 

--- a/sjasm/tables.cpp
+++ b/sjasm/tables.cpp
@@ -400,9 +400,17 @@ void CLabelTable::DumpForUnreal() {
 		}
 		int lvalue = LabelTable[i].value & PAGE_MASK;
 		ep = ln;
-		if (page < LABEL_PAGE_ROM) ep += sprintf(ep, "%02d", page&255);
-		*(ep++) = ':';
-		PrintHexAlt(ep, lvalue);
+
+		if (!Options::EmitVirtualLabels) {
+			if (page < LABEL_PAGE_ROM) ep += sprintf(ep, "%02d", page&255);
+			*(ep++) = ':';
+			PrintHexAlt(ep, lvalue);
+		}
+		else {
+			*(ep++) = ':';
+			PrintHexAlt(ep, LabelTable[i].value & 0xFFFF);
+		}
+
 		*(ep++) = ' ';
 		STRCPY(ep, LINEMAX-(ep-ln), LabelTable[i].name);
 		STRCAT(ep, LINEMAX, "\n");


### PR DESCRIPTION
Background:
During the development of OS for zx-compatible machines (look http://nedoos.ru) it is turned out that
the task or even the kernel may reside in just about any pages, that are not fixed at the application startup.
Thus, 'traditional' physical addresses in labels list for Unreal Speccy emulator rendered unusable.
This patch is assembler side one.

It adds --virtlabels command line option after which, labels are emitted like
:addr label
where addr is Z80 'virtual' address, prepended by colon.
