### PR TITLE
Set newlines to LF on check-out and check-in

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Auto-detect text vs. binary files and ensure newlines are always LF for
+# text files on check-out and check-in.
+* text=auto eol=lf


### PR DESCRIPTION
@ped7g Auto-detect text vs binary files and ensure newlines are always LF for text files on check-out and check-in. This will prevent test suite errors when building with MinGW on Windows.