### PR TITLE
Fixed CMakeLists.txt and Makefile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 ##############################################################
 
-cmake_minimum_required(VERSION 3.9.6)
+cmake_minimum_required(VERSION 3.18.0)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})
 
 project(sjasmplus)
@@ -71,7 +71,7 @@ if(ENABLE_LUA)
 	message(STATUS "Looking for Lua 5.4")
 
 	if(SYSTEM_LUA)
-		find_package(Lua "5.4" EXACT)
+		find_package(Lua "5.4" REQUIRED)
 	endif(SYSTEM_LUA)
 
 	if(LUA_FOUND)
@@ -82,10 +82,7 @@ if(ENABLE_LUA)
 		set(LUA_LIBRARY ${MY_LUA_LIBRARY})
 		set(LUA_INCLUDE_DIR ${MY_LUA_INCLUDE_DIR})
 		add_subdirectory(${LUA_INCLUDE_DIR})
-
-		target_include_directories(${MY_LUA_LIBRARY} PUBLIC
-            ${LUA_INCLUDE_DIR}
-		)
+		include_directories(${LUA_INCLUDE_DIR})
 	endif(LUA_FOUND)
 
 	add_definitions(-DUSE_LUA)

--- a/Makefile
+++ b/Makefile
@@ -54,15 +54,23 @@ MEMCHECK?=valgrind --leak-check=yes
 EXE_BASE_NAME=sjasmplus
 BUILD_DIR=build
 
+LUA_VER=5.4
+
 SUBDIR_BASE=sjasm
-SUBDIR_LUA=lua5.4
+SUBDIR_LUA=lua$(LUA_VER)
 SUBDIR_LUABRIDGE=LuaBridge/Source
 SUBDIR_CRC32C=crc32c
 SUBDIR_DOCS=docs
 SUBDIR_COV=coverage
 
-ifeq ($(USE_BUNDLED_LUA), 1)
+INCDIR_LUA=/usr/include/lua$(LUA_VER)
+
+ifeq ($(USE_LUA), 1)
 _LUA_CPPFLAGS=-I$(SUBDIR_LUA)
+endif
+
+ifeq ($(USE_BUNDLED_LUA), 0)
+_LUA_CPPFLAGS=-I$(INCDIR_LUA)
 endif
 
 # TODO too many lua5.4 warnings: -pedantic removed
@@ -75,6 +83,10 @@ CFLAGS+=$(CFLAGS_EXTRA)
 
 ifeq ($(USE_LUA), 1)
 LDFLAGS+=-ldl
+endif
+
+ifeq ($(USE_BUNDLED_LUA), 0)
+LDFLAGS+=-llua$(LUA_VER)
 endif
 
 ifdef DEBUG

--- a/lua5.4/CMakeLists.txt
+++ b/lua5.4/CMakeLists.txt
@@ -5,12 +5,12 @@
 #
 ##############################################################
 
-cmake_minimum_required(VERSION 3.9.6)
+cmake_minimum_required(VERSION 3.18.0)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})
 
 project(lua5.4)
 
-set(LUA_SOURCES 
+set(LUA_SOURCES
 	lapi.c
 	lauxlib.c
 	lbaselib.c
@@ -56,5 +56,6 @@ endif()
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -Wno-pedantic")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wno-pedantic")
 
-add_library(lua5.4 ${LUA_SOURCES})
+add_library(lua5.4 STATIC ${LUA_SOURCES})
 target_include_directories(lua5.4 PUBLIC include)
+


### PR DESCRIPTION
1. Fixed CMakeLists.txt, working correctly with Gentoo Ebuilds

Gentoo emerge was not able to install binaries with incorrectly linked Lua library.
It works now:
- system-lua enabled -> binary is linked dynamically
- system-lua disabled -> local Lua files are linked statically


2. Fixed Makefile, make USE_BUNDLED_LUA=0 works