### PR TITLE
Adds AMSTRADCPCPLUS and SAVECPR

### DIFF
--- a/asm-z80-sj.xml
+++ b/asm-z80-sj.xml
@@ -5,7 +5,7 @@
   sjasmplus z00m's variant: https://github.com/z00m128/sjasmplus
 
   Created: Peter Helcmanovsky <ped@7gods.org>
-  Version: 0.9.6 29/03/2022
+  Version: 0.9.7 20/08/2023
 
   To install locally for your KDE5 desktop environment, copy the XML file into:
     ~/.local/share/org.kde.syntax-highlighting/syntax/
@@ -14,6 +14,10 @@
 Changelog:
   // dd/mm/yyyy: version x.y (keep changelog in descending order)
   //   what was modified
+
+  20/08/2023: version 0.9.7
+    + new device: amstradcpcplus
+    + new directive: savecpr
 
   29/03/2022: version 0.9.6
     + new operator: exist
@@ -107,7 +111,7 @@ TODO missing things:
     - when more finished, try to propose to upstream: https://github.com/KDE/syntax-highlighting/tree/master/data/syntax
 
 -->
-<language name="Z80 (sjasmplus)" section="Assembler" version="16" kateversion="5.0" extensions="*.asm;*.a80;*.s" mimetype="" author="Peter Helcmanovsky (ped@7gods.org)" license="MIT">
+<language name="Z80 (sjasmplus)" section="Assembler" version="17" kateversion="5.0" extensions="*.asm;*.a80;*.s" mimetype="" author="Peter Helcmanovsky (ped@7gods.org)" license="MIT">
   <highlighting>
     <list name="registers">
       <!-- General purpose registers -->
@@ -331,6 +335,7 @@ TODO missing things:
       <item>savebin</item>
       <item>savecdt</item>
       <item>savecpcsna</item>
+      <item>savecpr</item>
       <item>savedev</item>
       <item>savehob</item>
       <item>savenex</item>
@@ -383,6 +388,7 @@ TODO missing things:
       <!-- known devices names -->
       <item>AMSTRADCPC464</item>
       <item>AMSTRADCPC6128</item>
+      <item>AMSTRADCPCPLUS</item>
       <item>NONE</item>
       <item>NOSLOT64K</item>
       <item>ZXSPECTRUM48</item>

--- a/docs/documentation.xml
+++ b/docs/documentation.xml
@@ -1298,6 +1298,7 @@ $$lab $$lab    <indexterm id="op_label_page"><primary>$$label</primary></indexte
       <link linkend="po_savenex">SAVENEX</link>,
       <link linkend="po_savecdt">SAVECDT</link>,
       <link linkend="po_savecpcsna">SAVECPCSNA</link>,
+      <link linkend="po_savecpr">SAVECPR</link>,
       <link linkend="po_saveamsdos">SAVEAMSDOS</link>,
       <link linkend="po_save3dos">SAVE3DOS</link>,
       <link linkend="po_savehob">SAVEHOB</link>,
@@ -1445,6 +1446,16 @@ StartProg:
             <listitem>
               <para>Has 4 slots (0-3) of size 0x4000 and 8 RAM pages (0-7) of 0x4000 (128K total). The default page mapping is
               { 0, 1, 2, 3 }.</para>
+            </listitem>
+          </varlistentry>
+
+          <varlistentry>
+            <term>AMSTRADCPCPLUS<indexterm id="device_cpcplus"><primary>AMSTRADCPCPLUS</primary></indexterm></term>
+
+            <listitem>
+              <para>Has 4 slots (0-3) of size 0x4000 and 32 RAM pages (0-31)
+              of 0x4000 (512K total). The default page mapping is { 0, 1, 2, 3
+              }.</para>
             </listitem>
           </varlistentry>
 
@@ -2095,6 +2106,7 @@ counter = counter + 1
  NOSLOT64K      ; Single slot (slot 0) covering full 64kiB address range of Z80, 32 pages
  AMSTRADCPC464  ; Amstrad CPC 464 (4 slots, 4 pages, slot/page size 0x4000, default map: 0, 1, 2, 3)
  AMSTRADCPC6128 ; Amstrad CPC 6128 (like 464 with 8 pages)
+ AMSTRADCPCPLUS ; Amstrad CPC Plus (like 464 with 32 pages)
 
  ;disable:
    DEVICE NONE
@@ -3029,7 +3041,7 @@ OUTPUT &lt;filename&gt;,a  ; append</synopsis>
             <para>SAVECDT HEADLESS &lt;cdtname&gt;,&lt;start&gt;,&lt;length&gt;[,&lt;sync&gt;[,&lt;format&gt;]]</para></term>
 
             <listitem>
-              <para><emphasis>Works only in Amstrad device emulation mode. See
+              <para><emphasis>Works only in AMSTRADCPC464 / AMSTRADCPC6128 real device emulation mode. See
               <link linkend="po_device">DEVICE</link>.</emphasis></para>
 
               <para>Manipulate CDT file (tape/TZX file format used by Amstrad CPC emulators).<example>
@@ -3080,6 +3092,28 @@ OUTPUT &lt;filename&gt;,a  ; append</synopsis>
 START  .... ;some code
     RET
     SAVECPCSNA "game.sna",START ;save snapshot to file game.sna. Start address is START ($1200)</programlisting></para>
+                </example></para>
+            </listitem>
+          </varlistentry>
+
+          <varlistentry>
+            <term>SAVECPR<indexterm id="po_savecpr"><primary>SAVECPR</primary></indexterm>
+                &lt;filename&gt;[,&lt;size = 32&gt;]</term>
+
+            <listitem>
+              <para><emphasis>Works only in virtual device emulation mode. See
+              <link linkend="po_device">DEVICE</link>.</emphasis></para>
+
+              <para>Saves memory per blocks of 16KiB; 1 means 16KiB, 2 means
+                32KiB, ...<example>
+                  <title></title>
+
+                  <para><programlisting>    DEVICE AMSTRADCPCPLUS
+    ... some code ...
+
+    ; by default a size of 32 (512KiB) is used
+    ; here we save a block of 16KiB
+    SAVECPR "code.cpr", 1</programlisting></para>
                 </example></para>
             </listitem>
           </varlistentry>

--- a/sjasm/devices.cpp
+++ b/sjasm/devices.cpp
@@ -54,6 +54,15 @@ bool IsAmstradCPCDevice(const char* name) {
 	return true;
 }
 
+bool IsAmstradPLUSDevice(const char* name) {
+	if (nullptr == name) return false;
+	if (strcmp(name, "AMSTRADCPCPLUS"))
+	{
+		return false;
+	}
+	return true;
+}
+
 static void initRegularSlotDevice(CDevice* const device, const int32_t slotSize, const int32_t slotCount,
 								  const int pageCount, const int* const initialPages) {
 	for (int32_t slotAddress = 0; slotAddress < slotSize * slotCount; slotAddress += slotSize) {
@@ -181,6 +190,13 @@ static void DeviceAmstradCPC6128(CDevice** dev, CDevice* parent, aint ramtop) {
 	initRegularSlotDevice(*dev, 0x4000, 4, 8, initialPages);
 }
 
+static void DeviceAmstradCPCPLUS(CDevice** dev, CDevice* parent, aint ramtop) {
+	if (ramtop) WarningById(W_NO_RAMTOP);
+	*dev = new CDevice("AMSTRADCPCPLUS", parent);
+	const int initialPages[] = { 0, 1, 2, 3 };
+	initRegularSlotDevice(*dev, 0x4000, 4, 32, initialPages);	// 32*16kiB = 512MiB (maximum cartridge size)
+}
+
 static bool SetUserDefinedDevice(const char* id, CDevice** dev, CDevice* parent, aint ramtop) {
 	auto findIt = std::find_if(
 		DefDevices.begin(), DefDevices.end(),
@@ -240,6 +256,8 @@ bool SetDevice(const char *const_id, const aint ramtop) {
 				DeviceAmstradCPC464(dev, parent, ramtop);
 			} else if (cmphstr(id, "amstradcpc6128")) {
 				DeviceAmstradCPC6128(dev, parent, ramtop);
+			} else if (cmphstr(id, "amstradcpcplus")) {
+				DeviceAmstradCPCPLUS(dev, parent, ramtop);
 			} else if (!SetUserDefinedDevice(id, dev, parent, ramtop)) {
 				return false;
 			}

--- a/sjasm/devices.h
+++ b/sjasm/devices.h
@@ -28,6 +28,7 @@
 
 bool IsZXSpectrumDevice(const char *name);
 bool IsAmstradCPCDevice(const char* name);
+bool IsAmstradPLUSDevice(const char* name);
 bool SetDevice(const char *const_id, const aint ramtop = 0);
 const char* GetDeviceName();
 

--- a/sjasm/directives.cpp
+++ b/sjasm/directives.cpp
@@ -2217,6 +2217,7 @@ void InsertDirectives() {
 	DirectivesTable.insertd(".savecdt", dirSAVECDT);
 	DirectivesTable.insertd(".save3dos", dirSAVE3DOS);
 	DirectivesTable.insertd(".saveamsdos", dirSAVEAMSDOS);
+	DirectivesTable.insertd(".savecpr", dirSAVECPR);
 	DirectivesTable.insertd(".shellexec", dirSHELLEXEC);
 /*#ifdef WIN32
 	DirectivesTable.insertd(".winexec", dirWINEXEC);

--- a/sjasm/io_cpc.h
+++ b/sjasm/io_cpc.h
@@ -31,6 +31,7 @@
 
 void dirSAVECPCSNA();
 void dirSAVECDT();
+void dirSAVECPR();
 
 #endif
 

--- a/tests/devices/amstradcpc/cpc.asm
+++ b/tests/devices/amstradcpc/cpc.asm
@@ -56,3 +56,72 @@
     ORG 0xFFFE
     DB  "CCDD"  ; "DD" goes beyond 0x10000 -> lost (error reported)
     ASSERT {0} == "77"          ; still page 7 there
+
+    ; swap to the plus
+    DEVICE AMSTRADCPCPLUS
+
+    SLOT 0
+    PAGE 0 : ASSERT {0} == 0 : ORG 0x0000 : DB "00"
+    PAGE 1 : ASSERT {0} == 0 : ORG 0x0000 : DB "11"
+    PAGE 2 : ASSERT {0} == 0 : ORG 0x0000 : DB "22"
+    PAGE 3 : ASSERT {0} == 0 : ORG 0x0000 : DB "33"
+    PAGE 4 : ASSERT {0} == 0 : ORG 0x0000 : DB "44"
+    PAGE 5 : ASSERT {0} == 0 : ORG 0x0000 : DB "55"
+    PAGE 6 : ASSERT {0} == 0 : ORG 0x0000 : DB "66"
+    PAGE 7 : ASSERT {0} == 0 : ORG 0x0000 : DB "77"
+    PAGE 8 : ASSERT {0} == 0 : ORG 0x0000 : DB "88"
+    PAGE 9 : ASSERT {0} == 0 : ORG 0x0000 : DB "99"
+    PAGE 10 : ASSERT {0} == 0 : ORG 0x0000 : DB "AA"
+    PAGE 11 : ASSERT {0} == 0 : ORG 0x0000 : DB "BB"
+    PAGE 12 : ASSERT {0} == 0 : ORG 0x0000 : DB "CC"
+    PAGE 13 : ASSERT {0} == 0 : ORG 0x0000 : DB "DD"
+    PAGE 14 : ASSERT {0} == 0 : ORG 0x0000 : DB "EE"
+    PAGE 15 : ASSERT {0} == 0 : ORG 0x0000 : DB "FF"
+    PAGE 16 : ASSERT {0} == 0 : ORG 0x0000 : DB "GG"
+    PAGE 17 : ASSERT {0} == 0 : ORG 0x0000 : DB "HH"
+    PAGE 18 : ASSERT {0} == 0 : ORG 0x0000 : DB "II"
+    PAGE 19 : ASSERT {0} == 0 : ORG 0x0000 : DB "JJ"
+    PAGE 20 : ASSERT {0} == 0 : ORG 0x0000 : DB "KK"
+    PAGE 21 : ASSERT {0} == 0 : ORG 0x0000 : DB "LL"
+    PAGE 22 : ASSERT {0} == 0 : ORG 0x0000 : DB "MM"
+    PAGE 23 : ASSERT {0} == 0 : ORG 0x0000 : DB "NN"
+    PAGE 24 : ASSERT {0} == 0 : ORG 0x0000 : DB "OO"
+    PAGE 25 : ASSERT {0} == 0 : ORG 0x0000 : DB "PP"
+    PAGE 26 : ASSERT {0} == 0 : ORG 0x0000 : DB "QQ"
+    PAGE 27 : ASSERT {0} == 0 : ORG 0x0000 : DB "RR"
+    PAGE 28 : ASSERT {0} == 0 : ORG 0x0000 : DB "SS"
+    PAGE 29 : ASSERT {0} == 0 : ORG 0x0000 : DB "TT"
+    PAGE 30 : ASSERT {0} == 0 : ORG 0x0000 : DB "UU"
+    PAGE 31 : ASSERT {0} == 0 : ORG 0x0000 : DB "VV"
+
+    PAGE 32      ; error - non-existing page (page 31 should be still visible in slot 0)
+    ASSERT {0} == "VV"
+
+    SLOT 1 : PAGE 4 : ASSERT {0x4000} == "44" : PAGE 5 : ASSERT {0x4000} == "55"
+    SLOT 2 : PAGE 6 : ASSERT {0x8000} == "66" : PAGE 7 : ASSERT {0x8000} == "77"
+    SLOT 3 : PAGE 8 : ASSERT {0xC000} == "88" : PAGE 9 : ASSERT {0xC000} == "99"
+    SLOT 1 : PAGE 10 : ASSERT {0x4000} == "AA" : PAGE 11 : ASSERT {0x4000} == "BB"
+    SLOT 2 : PAGE 12 : ASSERT {0x8000} == "CC" : PAGE 13 : ASSERT {0x8000} == "DD"
+    SLOT 3 : PAGE 14 : ASSERT {0xC000} == "EE" : PAGE 15 : ASSERT {0xC000} == "FF"
+    SLOT 1 : PAGE 16 : ASSERT {0x4000} == "GG" : PAGE 17 : ASSERT {0x4000} == "HH"
+    SLOT 2 : PAGE 18 : ASSERT {0x8000} == "II" : PAGE 19 : ASSERT {0x8000} == "JJ"
+    SLOT 1 : PAGE 20 : ASSERT {0x4000} == "KK" : PAGE 21 : ASSERT {0x4000} == "LL"
+    SLOT 2 : PAGE 22 : ASSERT {0x8000} == "MM" : PAGE 23 : ASSERT {0x8000} == "NN"
+    SLOT 3 : PAGE 24 : ASSERT {0xC000} == "OO" : PAGE 25 : ASSERT {0xC000} == "PP"
+    SLOT 1 : PAGE 26 : ASSERT {0x4000} == "QQ" : PAGE 27 : ASSERT {0x4000} == "RR"
+    SLOT 2 : PAGE 28 : ASSERT {0x8000} == "SS" : PAGE 29 : ASSERT {0x8000} == "TT"
+    SLOT 3 : PAGE 30 : ASSERT {0xC000} == "UU" : PAGE 31 : ASSERT {0xC000} == "VV"
+    SLOT 2 : PAGE 30 : ASSERT {0x8000} == "UU" : PAGE 31 : ASSERT {0x8000} == "VV"
+    SLOT 3 : PAGE 26 : ASSERT {0xC000} == "QQ" : PAGE 27 : ASSERT {0xC000} == "RR"
+
+    SLOT 4      ; error
+
+    ; pages: 31:27:31:27
+    ORG 0xC000-2
+    DB  "AABB"
+    ASSERT {0x4000-2} == "AA"   ; should be visible also at these addresses
+    ASSERT {0x4000} == "BB"
+
+    ORG 0xFFFE
+    DB  "CCDD"  ; "DD" goes beyond 0x10000 -> lost (error reported)
+    ASSERT {0} == "VV"          ; still page 31 there

--- a/tests/devices/amstradcpc/cpc.lst
+++ b/tests/devices/amstradcpc/cpc.lst
@@ -1,125 +1,357 @@
 # file opened: cpc.asm
- 1    0000                  DEVICE AMSTRADCPC464
- 2    0000
- 3    0000                  SLOT 0
- 4    0000                  PAGE 0
- 4    0000                ORG 0x0000
- 4    0000 30 30          DB "00"
- 5    0002                  PAGE 1
- 5    0002                ORG 0x0000
- 5    0000 31 31          DB "11"
- 6    0002                  PAGE 2
- 6    0002                ORG 0x0000
- 6    0000 32 32          DB "22"
- 7    0002                  PAGE 3
- 7    0002                ORG 0x0000
- 7    0000 33 33          DB "33"
- 8    0002
+  1   0000                  DEVICE AMSTRADCPC464
+  2   0000
+  3   0000                  SLOT 0
+  4   0000                  PAGE 0
+  4   0000                ORG 0x0000
+  4   0000 30 30          DB "00"
+  5   0002                  PAGE 1
+  5   0002                ORG 0x0000
+  5   0000 31 31          DB "11"
+  6   0002                  PAGE 2
+  6   0002                ORG 0x0000
+  6   0000 32 32          DB "22"
+  7   0002                  PAGE 3
+  7   0002                ORG 0x0000
+  7   0000 33 33          DB "33"
+  8   0002
 cpc.asm(9): error: [PAGE] Page number must be in range 0..3: 4
- 9    0002                  PAGE 4      ; error - non-existing page (page 3 should be still visible in slot 0)
-10    0002                  ASSERT {0} == "33"
-11    0002
-12    0002                  SLOT 1
-12    0002                PAGE 0
-12    0002                ASSERT {0x4000} == "00"
-12    0002                PAGE 1
-12    0002                ASSERT {0x4000} == "11"
-13    0002                  SLOT 2
-13    0002                PAGE 2
-13    0002                ASSERT {0x8000} == "22"
-13    0002                PAGE 3
-13    0002                ASSERT {0x8000} == "33"
-14    0002                  SLOT 3
-14    0002                PAGE 0
-14    0002                ASSERT {0xC000} == "00"
-14    0002                PAGE 1
-14    0002                ASSERT {0xC000} == "11"
-15    0002
+  9   0002                  PAGE 4      ; error - non-existing page (page 3 should be still visible in slot 0)
+ 10   0002                  ASSERT {0} == "33"
+ 11   0002
+ 12   0002                  SLOT 1
+ 12   0002                PAGE 0
+ 12   0002                ASSERT {0x4000} == "00"
+ 12   0002                PAGE 1
+ 12   0002                ASSERT {0x4000} == "11"
+ 13   0002                  SLOT 2
+ 13   0002                PAGE 2
+ 13   0002                ASSERT {0x8000} == "22"
+ 13   0002                PAGE 3
+ 13   0002                ASSERT {0x8000} == "33"
+ 14   0002                  SLOT 3
+ 14   0002                PAGE 0
+ 14   0002                ASSERT {0xC000} == "00"
+ 14   0002                PAGE 1
+ 14   0002                ASSERT {0xC000} == "11"
+ 15   0002
 cpc.asm(16): error: [SLOT] Slot number must be in range 0..3, or exact starting address of slot
-16    0002                  SLOT 4      ; error
-17    0002
-18    0002                  ; pages: 3:1:3:1
-19    0002                  ORG 0xC000-2
-20    BFFE 41 41 42 42      DB  "AABB"
-21    C002                  ASSERT {0x4000-2} == "AA"   ; should be visible also at these addresses
-22    C002                  ASSERT {0x4000} == "BB"
-23    C002
-24    C002                  ORG 0xFFFE
+ 16   0002                  SLOT 4      ; error
+ 17   0002
+ 18   0002                  ; pages: 3:1:3:1
+ 19   0002                  ORG 0xC000-2
+ 20   BFFE 41 41 42 42      DB  "AABB"
+ 21   C002                  ASSERT {0x4000-2} == "AA"   ; should be visible also at these addresses
+ 22   C002                  ASSERT {0x4000} == "BB"
+ 23   C002
+ 24   C002                  ORG 0xFFFE
 cpc.asm(25): error: Write outside of device memory at: 65536
-25    FFFE 43 43 44 44      DB  "CCDD"  ; "DD" goes beyond 0x10000 -> lost (error reported)
-26    0002                  ASSERT {0} == "33"          ; still page 3 there
-27    0002
-28    0002                  ; swap to the 6128
-29    0002                  DEVICE AMSTRADCPC6128
-30    0002
-31    0002                  SLOT 0
-32    0002                  PAGE 0
-32    0002                ASSERT {0} == 0
-32    0002                ORG 0x0000
-32    0000 30 30          DB "00"
-33    0002                  PAGE 1
-33    0002                ASSERT {0} == 0
-33    0002                ORG 0x0000
-33    0000 31 31          DB "11"
-34    0002                  PAGE 2
-34    0002                ASSERT {0} == 0
-34    0002                ORG 0x0000
-34    0000 32 32          DB "22"
-35    0002                  PAGE 3
-35    0002                ASSERT {0} == 0
-35    0002                ORG 0x0000
-35    0000 33 33          DB "33"
-36    0002                  PAGE 4
-36    0002                ASSERT {0} == 0
-36    0002                ORG 0x0000
-36    0000 34 34          DB "44"
-37    0002                  PAGE 5
-37    0002                ASSERT {0} == 0
-37    0002                ORG 0x0000
-37    0000 35 35          DB "55"
-38    0002                  PAGE 6
-38    0002                ASSERT {0} == 0
-38    0002                ORG 0x0000
-38    0000 36 36          DB "66"
-39    0002                  PAGE 7
-39    0002                ASSERT {0} == 0
-39    0002                ORG 0x0000
-39    0000 37 37          DB "77"
-40    0002
+ 25   FFFE 43 43 44 44      DB  "CCDD"  ; "DD" goes beyond 0x10000 -> lost (error reported)
+ 26   0002                  ASSERT {0} == "33"          ; still page 3 there
+ 27   0002
+ 28   0002                  ; swap to the 6128
+ 29   0002                  DEVICE AMSTRADCPC6128
+ 30   0002
+ 31   0002                  SLOT 0
+ 32   0002                  PAGE 0
+ 32   0002                ASSERT {0} == 0
+ 32   0002                ORG 0x0000
+ 32   0000 30 30          DB "00"
+ 33   0002                  PAGE 1
+ 33   0002                ASSERT {0} == 0
+ 33   0002                ORG 0x0000
+ 33   0000 31 31          DB "11"
+ 34   0002                  PAGE 2
+ 34   0002                ASSERT {0} == 0
+ 34   0002                ORG 0x0000
+ 34   0000 32 32          DB "22"
+ 35   0002                  PAGE 3
+ 35   0002                ASSERT {0} == 0
+ 35   0002                ORG 0x0000
+ 35   0000 33 33          DB "33"
+ 36   0002                  PAGE 4
+ 36   0002                ASSERT {0} == 0
+ 36   0002                ORG 0x0000
+ 36   0000 34 34          DB "44"
+ 37   0002                  PAGE 5
+ 37   0002                ASSERT {0} == 0
+ 37   0002                ORG 0x0000
+ 37   0000 35 35          DB "55"
+ 38   0002                  PAGE 6
+ 38   0002                ASSERT {0} == 0
+ 38   0002                ORG 0x0000
+ 38   0000 36 36          DB "66"
+ 39   0002                  PAGE 7
+ 39   0002                ASSERT {0} == 0
+ 39   0002                ORG 0x0000
+ 39   0000 37 37          DB "77"
+ 40   0002
 cpc.asm(41): error: [PAGE] Page number must be in range 0..7: 8
-41    0002                  PAGE 8      ; error - non-existing page (page 7 should be still visible in slot 0)
-42    0002                  ASSERT {0} == "77"
-43    0002
-44    0002                  SLOT 1
-44    0002                PAGE 4
-44    0002                ASSERT {0x4000} == "44"
-44    0002                PAGE 5
-44    0002                ASSERT {0x4000} == "55"
-45    0002                  SLOT 2
-45    0002                PAGE 6
-45    0002                ASSERT {0x8000} == "66"
-45    0002                PAGE 7
-45    0002                ASSERT {0x8000} == "77"
-46    0002                  SLOT 3
-46    0002                PAGE 4
-46    0002                ASSERT {0xC000} == "44"
-46    0002                PAGE 5
-46    0002                ASSERT {0xC000} == "55"
-47    0002
+ 41   0002                  PAGE 8      ; error - non-existing page (page 7 should be still visible in slot 0)
+ 42   0002                  ASSERT {0} == "77"
+ 43   0002
+ 44   0002                  SLOT 1
+ 44   0002                PAGE 4
+ 44   0002                ASSERT {0x4000} == "44"
+ 44   0002                PAGE 5
+ 44   0002                ASSERT {0x4000} == "55"
+ 45   0002                  SLOT 2
+ 45   0002                PAGE 6
+ 45   0002                ASSERT {0x8000} == "66"
+ 45   0002                PAGE 7
+ 45   0002                ASSERT {0x8000} == "77"
+ 46   0002                  SLOT 3
+ 46   0002                PAGE 4
+ 46   0002                ASSERT {0xC000} == "44"
+ 46   0002                PAGE 5
+ 46   0002                ASSERT {0xC000} == "55"
+ 47   0002
 cpc.asm(48): error: [SLOT] Slot number must be in range 0..3, or exact starting address of slot
-48    0002                  SLOT 4      ; error
-49    0002
-50    0002                  ; pages: 7:5:7:5
-51    0002                  ORG 0xC000-2
-52    BFFE 41 41 42 42      DB  "AABB"
-53    C002                  ASSERT {0x4000-2} == "AA"   ; should be visible also at these addresses
-54    C002                  ASSERT {0x4000} == "BB"
-55    C002
-56    C002                  ORG 0xFFFE
+ 48   0002                  SLOT 4      ; error
+ 49   0002
+ 50   0002                  ; pages: 7:5:7:5
+ 51   0002                  ORG 0xC000-2
+ 52   BFFE 41 41 42 42      DB  "AABB"
+ 53   C002                  ASSERT {0x4000-2} == "AA"   ; should be visible also at these addresses
+ 54   C002                  ASSERT {0x4000} == "BB"
+ 55   C002
+ 56   C002                  ORG 0xFFFE
 cpc.asm(57): error: Write outside of device memory at: 65536
-57    FFFE 43 43 44 44      DB  "CCDD"  ; "DD" goes beyond 0x10000 -> lost (error reported)
-58    0002                  ASSERT {0} == "77"          ; still page 7 there
-59    0002
+ 57   FFFE 43 43 44 44      DB  "CCDD"  ; "DD" goes beyond 0x10000 -> lost (error reported)
+ 58   0002                  ASSERT {0} == "77"          ; still page 7 there
+ 59   0002
+ 60   0002                  ; swap to the plus
+ 61   0002                  DEVICE AMSTRADCPCPLUS
+ 62   0002
+ 63   0002                  SLOT 0
+ 64   0002                  PAGE 0
+ 64   0002                ASSERT {0} == 0
+ 64   0002                ORG 0x0000
+ 64   0000 30 30          DB "00"
+ 65   0002                  PAGE 1
+ 65   0002                ASSERT {0} == 0
+ 65   0002                ORG 0x0000
+ 65   0000 31 31          DB "11"
+ 66   0002                  PAGE 2
+ 66   0002                ASSERT {0} == 0
+ 66   0002                ORG 0x0000
+ 66   0000 32 32          DB "22"
+ 67   0002                  PAGE 3
+ 67   0002                ASSERT {0} == 0
+ 67   0002                ORG 0x0000
+ 67   0000 33 33          DB "33"
+ 68   0002                  PAGE 4
+ 68   0002                ASSERT {0} == 0
+ 68   0002                ORG 0x0000
+ 68   0000 34 34          DB "44"
+ 69   0002                  PAGE 5
+ 69   0002                ASSERT {0} == 0
+ 69   0002                ORG 0x0000
+ 69   0000 35 35          DB "55"
+ 70   0002                  PAGE 6
+ 70   0002                ASSERT {0} == 0
+ 70   0002                ORG 0x0000
+ 70   0000 36 36          DB "66"
+ 71   0002                  PAGE 7
+ 71   0002                ASSERT {0} == 0
+ 71   0002                ORG 0x0000
+ 71   0000 37 37          DB "77"
+ 72   0002                  PAGE 8
+ 72   0002                ASSERT {0} == 0
+ 72   0002                ORG 0x0000
+ 72   0000 38 38          DB "88"
+ 73   0002                  PAGE 9
+ 73   0002                ASSERT {0} == 0
+ 73   0002                ORG 0x0000
+ 73   0000 39 39          DB "99"
+ 74   0002                  PAGE 10
+ 74   0002                ASSERT {0} == 0
+ 74   0002                ORG 0x0000
+ 74   0000 41 41          DB "AA"
+ 75   0002                  PAGE 11
+ 75   0002                ASSERT {0} == 0
+ 75   0002                ORG 0x0000
+ 75   0000 42 42          DB "BB"
+ 76   0002                  PAGE 12
+ 76   0002                ASSERT {0} == 0
+ 76   0002                ORG 0x0000
+ 76   0000 43 43          DB "CC"
+ 77   0002                  PAGE 13
+ 77   0002                ASSERT {0} == 0
+ 77   0002                ORG 0x0000
+ 77   0000 44 44          DB "DD"
+ 78   0002                  PAGE 14
+ 78   0002                ASSERT {0} == 0
+ 78   0002                ORG 0x0000
+ 78   0000 45 45          DB "EE"
+ 79   0002                  PAGE 15
+ 79   0002                ASSERT {0} == 0
+ 79   0002                ORG 0x0000
+ 79   0000 46 46          DB "FF"
+ 80   0002                  PAGE 16
+ 80   0002                ASSERT {0} == 0
+ 80   0002                ORG 0x0000
+ 80   0000 47 47          DB "GG"
+ 81   0002                  PAGE 17
+ 81   0002                ASSERT {0} == 0
+ 81   0002                ORG 0x0000
+ 81   0000 48 48          DB "HH"
+ 82   0002                  PAGE 18
+ 82   0002                ASSERT {0} == 0
+ 82   0002                ORG 0x0000
+ 82   0000 49 49          DB "II"
+ 83   0002                  PAGE 19
+ 83   0002                ASSERT {0} == 0
+ 83   0002                ORG 0x0000
+ 83   0000 4A 4A          DB "JJ"
+ 84   0002                  PAGE 20
+ 84   0002                ASSERT {0} == 0
+ 84   0002                ORG 0x0000
+ 84   0000 4B 4B          DB "KK"
+ 85   0002                  PAGE 21
+ 85   0002                ASSERT {0} == 0
+ 85   0002                ORG 0x0000
+ 85   0000 4C 4C          DB "LL"
+ 86   0002                  PAGE 22
+ 86   0002                ASSERT {0} == 0
+ 86   0002                ORG 0x0000
+ 86   0000 4D 4D          DB "MM"
+ 87   0002                  PAGE 23
+ 87   0002                ASSERT {0} == 0
+ 87   0002                ORG 0x0000
+ 87   0000 4E 4E          DB "NN"
+ 88   0002                  PAGE 24
+ 88   0002                ASSERT {0} == 0
+ 88   0002                ORG 0x0000
+ 88   0000 4F 4F          DB "OO"
+ 89   0002                  PAGE 25
+ 89   0002                ASSERT {0} == 0
+ 89   0002                ORG 0x0000
+ 89   0000 50 50          DB "PP"
+ 90   0002                  PAGE 26
+ 90   0002                ASSERT {0} == 0
+ 90   0002                ORG 0x0000
+ 90   0000 51 51          DB "QQ"
+ 91   0002                  PAGE 27
+ 91   0002                ASSERT {0} == 0
+ 91   0002                ORG 0x0000
+ 91   0000 52 52          DB "RR"
+ 92   0002                  PAGE 28
+ 92   0002                ASSERT {0} == 0
+ 92   0002                ORG 0x0000
+ 92   0000 53 53          DB "SS"
+ 93   0002                  PAGE 29
+ 93   0002                ASSERT {0} == 0
+ 93   0002                ORG 0x0000
+ 93   0000 54 54          DB "TT"
+ 94   0002                  PAGE 30
+ 94   0002                ASSERT {0} == 0
+ 94   0002                ORG 0x0000
+ 94   0000 55 55          DB "UU"
+ 95   0002                  PAGE 31
+ 95   0002                ASSERT {0} == 0
+ 95   0002                ORG 0x0000
+ 95   0000 56 56          DB "VV"
+ 96   0002
+cpc.asm(97): error: [PAGE] Page number must be in range 0..31: 32
+ 97   0002                  PAGE 32      ; error - non-existing page (page 31 should be still visible in slot 0)
+ 98   0002                  ASSERT {0} == "VV"
+ 99   0002
+100   0002                  SLOT 1
+100   0002                PAGE 4
+100   0002                ASSERT {0x4000} == "44"
+100   0002                PAGE 5
+100   0002                ASSERT {0x4000} == "55"
+101   0002                  SLOT 2
+101   0002                PAGE 6
+101   0002                ASSERT {0x8000} == "66"
+101   0002                PAGE 7
+101   0002                ASSERT {0x8000} == "77"
+102   0002                  SLOT 3
+102   0002                PAGE 8
+102   0002                ASSERT {0xC000} == "88"
+102   0002                PAGE 9
+102   0002                ASSERT {0xC000} == "99"
+103   0002                  SLOT 1
+103   0002                PAGE 10
+103   0002                ASSERT {0x4000} == "AA"
+103   0002                PAGE 11
+103   0002                ASSERT {0x4000} == "BB"
+104   0002                  SLOT 2
+104   0002                PAGE 12
+104   0002                ASSERT {0x8000} == "CC"
+104   0002                PAGE 13
+104   0002                ASSERT {0x8000} == "DD"
+105   0002                  SLOT 3
+105   0002                PAGE 14
+105   0002                ASSERT {0xC000} == "EE"
+105   0002                PAGE 15
+105   0002                ASSERT {0xC000} == "FF"
+106   0002                  SLOT 1
+106   0002                PAGE 16
+106   0002                ASSERT {0x4000} == "GG"
+106   0002                PAGE 17
+106   0002                ASSERT {0x4000} == "HH"
+107   0002                  SLOT 2
+107   0002                PAGE 18
+107   0002                ASSERT {0x8000} == "II"
+107   0002                PAGE 19
+107   0002                ASSERT {0x8000} == "JJ"
+108   0002                  SLOT 1
+108   0002                PAGE 20
+108   0002                ASSERT {0x4000} == "KK"
+108   0002                PAGE 21
+108   0002                ASSERT {0x4000} == "LL"
+109   0002                  SLOT 2
+109   0002                PAGE 22
+109   0002                ASSERT {0x8000} == "MM"
+109   0002                PAGE 23
+109   0002                ASSERT {0x8000} == "NN"
+110   0002                  SLOT 3
+110   0002                PAGE 24
+110   0002                ASSERT {0xC000} == "OO"
+110   0002                PAGE 25
+110   0002                ASSERT {0xC000} == "PP"
+111   0002                  SLOT 1
+111   0002                PAGE 26
+111   0002                ASSERT {0x4000} == "QQ"
+111   0002                PAGE 27
+111   0002                ASSERT {0x4000} == "RR"
+112   0002                  SLOT 2
+112   0002                PAGE 28
+112   0002                ASSERT {0x8000} == "SS"
+112   0002                PAGE 29
+112   0002                ASSERT {0x8000} == "TT"
+113   0002                  SLOT 3
+113   0002                PAGE 30
+113   0002                ASSERT {0xC000} == "UU"
+113   0002                PAGE 31
+113   0002                ASSERT {0xC000} == "VV"
+114   0002                  SLOT 2
+114   0002                PAGE 30
+114   0002                ASSERT {0x8000} == "UU"
+114   0002                PAGE 31
+114   0002                ASSERT {0x8000} == "VV"
+115   0002                  SLOT 3
+115   0002                PAGE 26
+115   0002                ASSERT {0xC000} == "QQ"
+115   0002                PAGE 27
+115   0002                ASSERT {0xC000} == "RR"
+116   0002
+cpc.asm(117): error: [SLOT] Slot number must be in range 0..3, or exact starting address of slot
+117   0002                  SLOT 4      ; error
+118   0002
+119   0002                  ; pages: 31:27:31:27
+120   0002                  ORG 0xC000-2
+121   BFFE 41 41 42 42      DB  "AABB"
+122   C002                  ASSERT {0x4000-2} == "AA"   ; should be visible also at these addresses
+123   C002                  ASSERT {0x4000} == "BB"
+124   C002
+125   C002                  ORG 0xFFFE
+cpc.asm(126): error: Write outside of device memory at: 65536
+126   FFFE 43 43 44 44      DB  "CCDD"  ; "DD" goes beyond 0x10000 -> lost (error reported)
+127   0002                  ASSERT {0} == "VV"          ; still page 31 there
+128   0002
 # file closed: cpc.asm
 
 Value    Label

--- a/tests/devices/amstradcpc/savecprCoverage.asm
+++ b/tests/devices/amstradcpc/savecprCoverage.asm
@@ -1,0 +1,13 @@
+; test-coverage cases not covered by regular tests
+
+    DEVICE AMSTRADCPC6128
+    SAVECPR "BadDevice.cpr", 2        ; error about wrong device
+
+    DEVICE NONE
+    SAVECPR "NoDevice.cpr", 1         ; error about none device
+
+    DEVICE AMSTRADCPCPLUS
+    SAVECPR "file.cpr", -1            ; negative number of pages
+    SAVECPR "file.cpr", &             ; invalid (parse) page value
+    SAVECPR "file.cpr", 33            ; page value out of bound
+    SAVECPR ".", 19                   ; fail to open file for write

--- a/tests/devices/amstradcpc/savecprCoverage.lst
+++ b/tests/devices/amstradcpc/savecprCoverage.lst
@@ -1,0 +1,26 @@
+# file opened: savecprCoverage.asm
+ 1    0000              ; test-coverage cases not covered by regular tests
+ 2    0000
+ 3    0000                  DEVICE AMSTRADCPC6128
+savecprCoverage.asm(4): error: [SAVECPR] is allowed only in AMSTRADCPCPLUS device mode
+ 4    0000                  SAVECPR "BadDevice.cpr", 2        ; error about wrong device
+ 5    0000
+ 6    0000                  DEVICE NONE
+savecprCoverage.asm(7): error: [SAVECPR] is allowed only in AMSTRADCPCPLUS device mode
+ 7    0000                  SAVECPR "NoDevice.cpr", 1         ; error about none device
+ 8    0000
+ 9    0000                  DEVICE AMSTRADCPCPLUS
+savecprCoverage.asm(10): error: [SAVECPR] only a size from 1 (16KiB) to 32 (512KiB) is allowed
+10    0000                  SAVECPR "file.cpr", -1            ; negative number of pages
+savecprCoverage.asm(11): error: Syntax error: &
+savecprCoverage.asm(11): error: Unexpected: &
+11    0000                  SAVECPR "file.cpr", &             ; invalid (parse) page value
+savecprCoverage.asm(12): error: [SAVECPR] only a size from 1 (16KiB) to 32 (512KiB) is allowed
+12    0000                  SAVECPR "file.cpr", 33            ; page value out of bound
+savecprCoverage.asm(13): error: [SAVECPR] Error opening file for write: .
+13    0000                  SAVECPR ".", 19                   ; fail to open file for write
+14    0000
+# file closed: savecprCoverage.asm
+
+Value    Label
+------ - -----------------------------------------------------------


### PR DESCRIPTION
* It adds `AMSTRADCPCPLUS` device (similar to AMSTRADCPC6128 but with 32 pages).
* It adds `SAVECPR` directive (allows to save the memory in a cpr file per blocks of 16 KiB - supported by cpc+ emulators).
* It adds tests for amstradcpcplus and savecpr

I updated documentation and  kate syntax highlighting. ~~Tests are missing - help needed !~~

All current tests passed.