### PR TITLE
migrating some of the file stuff to std::filesystem, in the naive hope of getting better cross-platform compatibility

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -42,6 +42,9 @@ extern struct tm *gmtime (const time_t *__timer) __THROW;
 extern struct tm *localtime (const time_t *__timer) __THROW;
 -------------
 
+tables.cpp:1178: error not covered by tests why?? "if (haakjes) { Error("closing } missing"); }"
+also reader.cpp:967: case 'w'*2+'o' (smallcase "word"? or are coverage data misaligned again? also doesn't feel like case matters in other cases)
+
 unittest-cpp seems to be pretty dead now, consider migration, for example to https://github.com/neacsum/utpp
 (author claims C++20, header only and somewhat more compatible with GoogleTest)
 

--- a/cpp-src-tests/ut_io.cpp
+++ b/cpp-src-tests/ut_io.cpp
@@ -122,27 +122,26 @@ TEST(SjIo_FilenameExtPos_WithInit) {
 TEST(SjIo_ConstructDefaultFilename) {
 	// verify the global sourceFiles variable is empty for this unit testing
 	CHECK_EQUAL(0UL, sourceFiles.size());
-	char fname[101];
 	// check the "checkIfDestIsEmpty" argument functionality, and default basename "asm"
-	fname[0] = 'x';	fname[1] = 0;
-	ConstructDefaultFilename(fname, 101, ".ext");
+	std::filesystem::path fname {"x"};
+	ConstructDefaultFilename(fname, ".ext");
 	CHECK_EQUAL("x", fname);
-	ConstructDefaultFilename(fname, 101, ".ext", true);
+	ConstructDefaultFilename(fname, ".ext", true);
 	CHECK_EQUAL("x", fname);
-	ConstructDefaultFilename(fname, 101, ".ext", false);
+	ConstructDefaultFilename(fname, ".ext", false);
 	CHECK_EQUAL("asm.ext", fname);
-	fname[0] = 0;
-	ConstructDefaultFilename(fname, 101, ".ext");
+	fname.clear();
+	ConstructDefaultFilename(fname, ".ext");
 	CHECK_EQUAL("asm.ext", fname);
 	// check if first explicit filename is picked
 	sourceFiles.push_back(SSource(1));
-	ConstructDefaultFilename(fname, 101, ".ext", false);
+	ConstructDefaultFilename(fname, ".ext", false);
 	CHECK_EQUAL("asm.ext", fname);
 	sourceFiles.push_back(SSource(".f1.asm"));
-	ConstructDefaultFilename(fname, 101, ".ext", false);
+	ConstructDefaultFilename(fname, ".ext", false);
 	CHECK_EQUAL(".f1.ext", fname);
 	sourceFiles.push_back(SSource("f2.asm"));
-	ConstructDefaultFilename(fname, 101, ".ext", false);
+	ConstructDefaultFilename(fname, ".ext", false);
 	CHECK_EQUAL(".f1.ext", fname);
 	// empty the global sourceFiles again
 	sourceFiles.clear();

--- a/sjasm/directives.cpp
+++ b/sjasm/directives.cpp
@@ -1283,7 +1283,7 @@ static void dirLABELSLIST() {
 	}
 	std::unique_ptr<char[]> opt(GetOutputFileName(lp));
 	if (opt[0]) {
-		STRCPY(Options::UnrealLabelListFName, LINEMAX, opt.get());
+		Options::UnrealLabelListFName = opt.get();
 		Options::EmitVirtualLabels = false;
 		if (comma(lp)) {
 			aint virtualLabelsArg;
@@ -1306,11 +1306,11 @@ static void dirCSPECTMAP() {
 	}
 	std::unique_ptr<char[]> fName(GetOutputFileName(lp));
 	if (fName[0]) {
-		STRCPY(Options::CSpectMapFName, LINEMAX, fName.get());
+		Options::CSpectMapFName = fName.get();
 	} else {		// create default map file name from current source file name (appends ".map")
 		assert(!sourcePosStack.empty());
-		STRCPY(Options::CSpectMapFName, LINEMAX-5, sourcePosStack.back().filename);
-		STRCAT(Options::CSpectMapFName, LINEMAX-1, ".map");
+		Options::CSpectMapFName = sourcePosStack.back().filename;
+		Options::CSpectMapFName += ".map";
 	}
 	// remember page size of current device (in case the source is multi-device later)
 	Options::CSpectMapPageSize = Device->GetPage(0)->Size;
@@ -1616,16 +1616,11 @@ static void dirEXPORT() {
 	aint val;
 	char* n, * p;
 
-	if (!Options::ExportFName[0]) {
+	if (Options::ExportFName.empty()) {
 		assert(!sourcePosStack.empty());
-		STRCPY(Options::ExportFName, LINEMAX, sourcePosStack.back().filename);
-		if (!(p = strchr(Options::ExportFName, '.'))) {
-			p = Options::ExportFName;
-		} else {
-			*p = 0;
-		}
-		STRCAT(p, LINEMAX, ".exp");
-		Warning("[EXPORT] Filename for exportfile was not indicated. Output will be in", Options::ExportFName, W_EARLY);
+		Options::ExportFName = sourcePosStack.back().filename;
+		Options::ExportFName.replace_extension(".exp");
+		Warning("[EXPORT] Filename for exportfile was not indicated. Output will be in", Options::ExportFName.string().c_str(), W_EARLY);
 	}
 	if (!(n = p = GetID(lp))) {
 		Error("[EXPORT] Syntax error", lp, SUPPRESS);

--- a/sjasm/io_snapshots.cpp
+++ b/sjasm/io_snapshots.cpp
@@ -29,13 +29,13 @@
 #include "sjdefs.h"
 
 // report error and close the file
-static bool writeError(const char* fname, FILE* & fileToClose) {
-	Error("Write error (disk full?)", fname, IF_FIRST);
+static bool writeError(const std::filesystem::path & fname, FILE* & fileToClose) {
+	Error("Write error (disk full?)", fname.string().c_str(), IF_FIRST);
 	fclose(fileToClose);
 	return false;
 }
 
-bool SaveSNA_ZX(const char* fname, word start) {
+bool SaveSNA_ZX(const std::filesystem::path & fname, word start) {
 	// for Lua
 	if (!DeviceID) {
 		Error("[SAVESNA] Only for real device emulation mode.");
@@ -47,7 +47,7 @@ bool SaveSNA_ZX(const char* fname, word start) {
 
 	FILE* ff;
 	if (!FOPEN_ISOK(ff, fname, "wb")) {
-		Error("opening file for write", fname);
+		Error("opening file for write", fname.string().c_str());
 		return false;
 	}
 
@@ -139,7 +139,7 @@ bool SaveSNA_ZX(const char* fname, word start) {
 	}
 
 	if (128*1024 < Device->PagesCount * Device->GetPage(0)->Size) {
-		WarningById(W_SNA_128, fname);
+		WarningById(W_SNA_128, fname.string().c_str());
 	}
 
 	fclose(ff);

--- a/sjasm/io_snapshots.h
+++ b/sjasm/io_snapshots.h
@@ -31,7 +31,7 @@
 #ifndef __IO_SNAPSHOTS
 #define __IO_SNAPSHOTS
 
-bool SaveSNA_ZX(const char* fname, word start);
+bool SaveSNA_ZX(const std::filesystem::path & fname, word start);
 
 #endif
 

--- a/sjasm/io_tape.cpp
+++ b/sjasm/io_tape.cpp
@@ -42,19 +42,19 @@ static bool has_screen_changes();
 static aint remove_unused_space(unsigned char* ram, aint length);
 static aint detect_ram_start(unsigned char* ram, aint length);
 
-int TAP_SaveEmpty(char* fname) {
+int TAP_SaveEmpty(const std::filesystem::path & fname) {
 	FILE* ff;
 	if (!FOPEN_ISOK(ff, fname, "wb")) {
-		Error("opening file for write", fname); return 0;
+		Error("opening file for write", fname.string().c_str()); return 0;
 	}
 	fclose(ff);
 	return 1;
 }
 
-int TAP_SaveBlock(char* fname, unsigned char flag, const char *ftapname, int start, int length, int param2, int param3) {
+int TAP_SaveBlock(const std::filesystem::path & fname, unsigned char flag, const char *ftapname, int start, int length, int param2, int param3) {
 	FILE* fpout;
 	if (!FOPEN_ISOK(fpout, fname, "ab")) {
-		Error("opening file for append", fname, FATAL);
+		Error("opening file for append", fname.string().c_str(), FATAL);
 	}
 
 	if (length + start > 0x10000) {
@@ -133,10 +133,10 @@ int TAP_SaveBlock(char* fname, unsigned char flag, const char *ftapname, int sta
 	return 1;
 }
 
-int TAP_SaveSnapshot(char* fname, unsigned short start) {
+int TAP_SaveSnapshot(const std::filesystem::path & fname, unsigned short start) {
 	FILE* fpout;
 	if (!FOPEN_ISOK(fpout, fname, "wb")) {
-		Error("opening file for write", fname, FATAL);
+		Error("opening file for write", fname.string().c_str(), FATAL);
 	}
 
 	aint datastart = 0x5E00;

--- a/sjasm/io_tape.h
+++ b/sjasm/io_tape.h
@@ -33,9 +33,9 @@ misrepresented as being the original software.
 
 enum ETapeHeaderType { BASIC = 0, NUMBERS, CHARS, CODE, HEADLESS = 255 };
 
-int TAP_SaveEmpty(char* fname);
-int TAP_SaveBlock(char* fname, unsigned char flag, const char *ftapname, int start, int length, int param2, int param3);
-int TAP_SaveSnapshot(char* fname, unsigned short start);
+int TAP_SaveEmpty(const std::filesystem::path & fname);
+int TAP_SaveBlock(const std::filesystem::path & fname, unsigned char flag, const char *ftapname, int start, int length, int param2, int param3);
+int TAP_SaveSnapshot(const std::filesystem::path & fname, unsigned short start);
 
 #endif
 

--- a/sjasm/io_trd.cpp
+++ b/sjasm/io_trd.cpp
@@ -181,10 +181,10 @@ static int saveEmptyWrite(FILE* ff, byte* buf, const char label[8]) {
 	return 1;
 }
 
-bool TRD_SaveEmpty(const char* fname, const char label[8]) {
+bool TRD_SaveEmpty(const std::filesystem::path & fname, const char label[8]) {
 	FILE* ff;
-	if (!FOPEN_ISOK(ff, fname, "wb")) {
-		Error("opening file for write", fname, IF_FIRST);
+	if (!fname.has_filename() || !FOPEN_ISOK(ff, fname, "wb")) {
+		Error("opening file for write", fname.string().c_str(), IF_FIRST);
 		return 0;
 	}
 	byte* buf = (byte*) calloc(STrdDisc::SECTORS_PER_TRACK*STrdDisc::SECTOR_SZ, sizeof(byte));
@@ -192,7 +192,7 @@ bool TRD_SaveEmpty(const char* fname, const char label[8]) {
 	int result = saveEmptyWrite(ff, buf, label);
 	free(buf);
 	fclose(ff);
-	if (!result) Error("Write error (disk full?)", fname, IF_FIRST);
+	if (!result) Error("Write error (disk full?)", fname.string().c_str(), IF_FIRST);
 	return result;
 }
 
@@ -224,14 +224,14 @@ ETrdFileName TRD_FileNameToBytes(const char* inputName, byte binName[12], int & 
 	return INVALID_EXTENSION;
 }
 
-static int ReturnWithError(const char* errorText, const char* fname, FILE* fileToClose) {
+static int ReturnWithError(const char* errorText, const std::filesystem::path & fname, FILE* fileToClose) {
 	if (nullptr != fileToClose) fclose(fileToClose);
-	Error(errorText, fname, IF_FIRST);
+	Error(errorText, fname.string().c_str(), IF_FIRST);
 	return 0;
 }
 
 // use autostart == -1 to disable it (the valid autostart is 0..9999 as line number of BASIC program)
-bool TRD_AddFile(const char* fname, const char* fhobname, int start, int length, int autostart, bool replace, bool addplace, int lengthMinusVars) {
+bool TRD_AddFile(const std::filesystem::path & fname, const char* fhobname, int start, int length, int autostart, bool replace, bool addplace, int lengthMinusVars) {
 	// do some preliminary checks with file name and autostart - prepare final catalog entry data
 	union {
 		STrdFile trdf;			// structure to hold future form of catalog record about new file
@@ -366,7 +366,7 @@ bool TRD_AddFile(const char* fname, const char* fhobname, int start, int length,
 		if (STrdHead::NUM_OF_FILES_MAX != fileIndex) {
 			// to keep legacy behaviour of older sjasmplus versions, this is just warning
 			// and the same file will be added to end of directory any way
-			WarningById(W_TRD_DUPLICATE, fname);
+			WarningById(W_TRD_DUPLICATE, fname.string().c_str());
 		}
 		fileIndex = trdHead.info.numOfFiles;
 	}
@@ -485,7 +485,7 @@ bool TRD_AddFile(const char* fname, const char* fhobname, int start, int length,
 	return 1;
 }
 
-int TRD_PrepareIncFile(const char* trdname, const char* filename, aint & offset, aint & length, const bool systemPathsFirst) {
+int TRD_PrepareIncFile(const std::filesystem::path & trdname, const char* filename, aint & offset, aint & length, const bool systemPathsFirst) {
 	// parse filename into TRD file form (max 8+3, don't warn about 3-letter extension)
 	byte trdFormName[12];
 	int Lname = 0;
@@ -493,7 +493,7 @@ int TRD_PrepareIncFile(const char* trdname, const char* filename, aint & offset,
 
 	// read 9 sectors of disk into "trdHead" (contains root directory catalog and disk info data)
 	STrdHead trdHead;
-	char* fullTrdName = GetPath(trdname, nullptr, systemPathsFirst);
+	char* fullTrdName = GetPath(trdname.string().c_str(), nullptr, systemPathsFirst);	//FIXME path idea ready with refactoring^2
 	FILE* ff = SJ_fopen(fullTrdName, "rb");
 	free(fullTrdName);
 	fullTrdName = nullptr;

--- a/sjasm/io_trd.h
+++ b/sjasm/io_trd.h
@@ -33,9 +33,9 @@
 
 enum ETrdFileName { OK, INVALID_EXTENSION, THREE_LETTER_EXTENSION };
 
-bool TRD_SaveEmpty(const char* fname, const char label[8]);
+bool TRD_SaveEmpty(const std::filesystem::path & fname, const char label[8]);
 ETrdFileName TRD_FileNameToBytes(const char* inputName, byte binName[12], int & nameL);
-bool TRD_AddFile(const char* fname, const char* fhobname, int start, int length, int autostart, bool replace, bool addplace, int lengthMinusVars = -1);
+bool TRD_AddFile(const std::filesystem::path & fname, const char* fhobname, int start, int length, int autostart, bool replace, bool addplace, int lengthMinusVars = -1);
 
 /**
  * @brief Checks TRD file and return absolute offset + length into the raw file.
@@ -46,7 +46,7 @@ bool TRD_AddFile(const char* fname, const char* fhobname, int start, int length,
  * @param length data length (1 or more or INT_MAX to include all), and return value = data length
  * @return int 0 when error, 1 when offset + length are valid values into TRD image file
  */
-int TRD_PrepareIncFile(const char* trdname, const char* filename, aint & offset, aint & length, const bool systemPathsFirst);
+int TRD_PrepareIncFile(const std::filesystem::path & trdname, const char* filename, aint & offset, aint & length, const bool systemPathsFirst);
 
 #endif
 

--- a/sjasm/io_tzx.cpp
+++ b/sjasm/io_tzx.cpp
@@ -32,10 +32,10 @@ namespace TZXBlockId {
 	constexpr byte Pause = 0x20;
 }
 
-void TZX_CreateEmpty(const char* fname) {
+void TZX_CreateEmpty(const std::filesystem::path & fname) {
 	FILE* ff;
 	if (!FOPEN_ISOK(ff, fname, "wb")) {
-		Error("[TZX] Error opening file for write", fname, FATAL);
+		Error("[TZX] Error opening file for write", fname.string().c_str(), FATAL);
 	}
 
 	constexpr byte tzx_major_version = 1;
@@ -50,10 +50,11 @@ void TZX_CreateEmpty(const char* fname) {
 	fclose(ff);
 }
 
-void TZX_AppendPauseBlock(const char* fname, word pauseAfterMs) {
+void TZX_AppendPauseBlock(const std::filesystem::path & fname, uint16_t pauseAfterMs)
+{
 	FILE* ff;
 	if (!FOPEN_ISOK(ff, fname, "a+b")) {
-		Error("[TZX] Error opening file for append", fname, FATAL);
+		Error("[TZX] Error opening file for append", fname.string().c_str(), FATAL);
 	}
 	fputc(TZXBlockId::Pause, ff); // block id
 
@@ -62,10 +63,11 @@ void TZX_AppendPauseBlock(const char* fname, word pauseAfterMs) {
 	fclose(ff);
 }
 
-void TZX_AppendStandardBlock(const char* fname, const byte* buf, const aint buflen, word pauseAfterMs, byte sync) {
+void TZX_AppendStandardBlock(const std::filesystem::path & fname,
+							 const byte* buf, const aint buflen, word pauseAfterMs, byte sync) {
 	FILE* ff;
 	if (!FOPEN_ISOK(ff, fname, "a+b")) {
-		Error("[TZX] Error opening file for append", fname, FATAL);
+		Error("[TZX] Error opening file for append", fname.string().c_str(), FATAL);
 	}
 
 	const aint totalDataLen = buflen + 2; // + sync byte + checksum
@@ -85,10 +87,11 @@ void TZX_AppendStandardBlock(const char* fname, const byte* buf, const aint bufl
 	fclose(ff);
 }
 
-void TZX_AppendTurboBlock(const char* fname, const byte* buf, const aint buflen, const STZXTurboBlock& turbo) {
+void TZX_AppendTurboBlock(const std::filesystem::path & fname,
+						  const byte* buf, const aint buflen, const STZXTurboBlock& turbo) {
 	FILE* ff;
 	if (!FOPEN_ISOK(ff, fname, "a+b")) {
-		Error("[TZX] Error opening file for append", fname, FATAL);
+		Error("[TZX] Error opening file for append", fname.string().c_str(), FATAL);
 	}
 
 	fputc(TZXBlockId::Turbo, ff); // block id

--- a/sjasm/io_tzx.h
+++ b/sjasm/io_tzx.h
@@ -40,10 +40,10 @@ typedef struct STZXTurboBlock {
 	word PauseAfterMs;
 } STZXTurboBlock;
 
-void TZX_CreateEmpty(const char* fname);
-void TZX_AppendStandardBlock(const char* fname, const byte* buf, const aint buflen, word pauseAfterMs, byte sync);
-void TZX_AppendTurboBlock(const char* fname, const byte* buf, const aint buflen, const STZXTurboBlock& turbo);
-void TZX_AppendPauseBlock(const char* fname, word pauseAfterMs);
+void TZX_CreateEmpty(const std::filesystem::path & fname);
+void TZX_AppendStandardBlock(const std::filesystem::path & fname, const byte* buf, const aint buflen, word pauseAfterMs, byte sync);
+void TZX_AppendTurboBlock(const std::filesystem::path & fname, const byte* buf, const aint buflen, const STZXTurboBlock& turbo);
+void TZX_AppendPauseBlock(const std::filesystem::path & fname, word pauseAfterMs);
 
 #endif
 

--- a/sjasm/lua_sjasm.cpp
+++ b/sjasm/lua_sjasm.cpp
@@ -348,7 +348,7 @@ static bool lua_zx_trdimage_create(const char* trdname, const char* label = null
 	char* l8_ptr = l8;
 	while (label && *label && (l8_ptr - l8) < 8) *l8_ptr++ = *label++;
 	int positionsAdded = addLuaSourcePositions();	// add known script positions to sourcePosStack vector
-	bool result = TRD_SaveEmpty(trdname, l8);
+	bool result = TRD_SaveEmpty(trdname ? trdname : "", l8);
 	removeLuaSourcePositions(positionsAdded);
 	return result;
 }
@@ -362,7 +362,7 @@ bool lua_zx_trdimage_add_file(const char* trd, const char* file, int start, int 
 
 static bool lua_zx_save_snapshot_sna(const char* fname, word start) {
 	int positionsAdded = addLuaSourcePositions();	// add known script positions to sourcePosStack vector
-	bool result = SaveSNA_ZX(fname, start);
+	bool result = SaveSNA_ZX(fname ? fname : "", start);
 	removeLuaSourcePositions(positionsAdded);
 	return result;
 }
@@ -526,11 +526,11 @@ void dirINCLUDELUA() {
 		SkipToEol(lp);		// skip till EOL (colon), to avoid parsing file name
 		return;
 	}
-	std::unique_ptr<char[]> fnaam(GetFileName(lp));
+	const std::filesystem::path fnaam = GetFileName(lp);
 	EDelimiterType dt = GetDelimiterOfLastFileName();
-	char* fullpath = GetPath(fnaam.get(), NULL, DT_ANGLE == dt);
+	char* fullpath = GetPath(fnaam.string().c_str(), NULL, DT_ANGLE == dt);	//FIXME fits input path idea
 	if (!fullpath[0]) {
-		Error("[INCLUDELUA] File doesn't exist", fnaam.get(), EARLY);
+		Error("[INCLUDELUA] File doesn't exist", fnaam.string().c_str(), EARLY);
 	} else {
 		extraErrorWarningPrefix = lua_err_prefix;
 		fileNameFull = ArchiveFilename(fullpath);	// get const pointer into archive

--- a/sjasm/lua_sjasm.cpp
+++ b/sjasm/lua_sjasm.cpp
@@ -414,7 +414,7 @@ static void lua_impl_init() {
 			.addFunction("set_page", lua_sj_set_page)
 			.addFunction("set_slot", lua_sj_set_slot)
 			// MMU API will be not added, it is too dynamic, and _pc("MMU ...") works
-			.addFunction("file_exists", FileExists)
+			.addFunction("file_exists", FileExistsCstr)
 		.endNamespace()
 		.beginNamespace("zx")
 			.addFunction("trdimage_create_i", lua_zx_trdimage_create)

--- a/sjasm/reader.h
+++ b/sjasm/reader.h
@@ -78,8 +78,9 @@ void GetStructText(char*& p, aint len, byte* data, const byte* initData = nullpt
 int GetBits(char*& p, int e[]);
 int GetBytesHexaText(char*& p, int e[]);
 int cmphstr(char*& p1, const char* p2, bool allowParenthesisEnd = false);		// p2 must be lowercase to match both cases
-char* GetFileName(char*& p, bool convertslashes=true);
-char* GetOutputFileName(char*& p, bool convertslashes=true);	// prepends the filename with OutPrefix
+std::string GetDelimitedString(char*& p);             // get some string within delimiters (none, quotes, apostrophes, chevron)
+std::filesystem::path GetFileName(char*& p);          // get string in delimiters, remember delimiter and convert slashes
+std::filesystem::path GetOutputFileName(char*& p);    // GetFileName plus prepends the filename with OutPrefix
 EDelimiterType GetDelimiterOfLastFileName();	// DT_NONE if no GetFileName was called
 bool isLabelStart(const char *p, bool modifiersAllowed = true);
 int islabchar(char p);

--- a/sjasm/reader.h
+++ b/sjasm/reader.h
@@ -77,11 +77,12 @@ int GetBytes(char*& p, int e[], int add, int dc);
 void GetStructText(char*& p, aint len, byte* data, const byte* initData = nullptr);	// initData indicate "{}" is required for multi-value init
 int GetBits(char*& p, int e[]);
 int GetBytesHexaText(char*& p, int e[]);
-int cmphstr(char*& p1, const char* p2, bool allowParenthesisEnd = false);		// p2 must be lowercase to match both cases
-std::string GetDelimitedString(char*& p);             // get some string within delimiters (none, quotes, apostrophes, chevron)
-std::filesystem::path GetFileName(char*& p);          // get string in delimiters, remember delimiter and convert slashes
-std::filesystem::path GetOutputFileName(char*& p);    // GetFileName plus prepends the filename with OutPrefix
-EDelimiterType GetDelimiterOfLastFileName();	// DT_NONE if no GetFileName was called
+int cmphstr(char*& p1, const char* p2, bool allowParenthesisEnd = false);   // p2 must be lowercase to match both cases
+std::pair<std::string, EDelimiterType> GetDelimitedStringEx(char*& p);      // get some string within delimiters (none, quotes, apostrophes, chevron)
+std::string GetDelimitedString(char*& p);                                   // get some string within delimiters (none, quotes, apostrophes, chevron)
+std::filesystem::path GetFileName(char*& p, const std::filesystem::path & pathPrefix = ""); // get string in delimiters, remember delimiter, convert slashes, prepend pathPrefix
+std::filesystem::path GetOutputFileName(char*& p);                          // GetFileName with pathPrefix = OutPrefix
+EDelimiterType GetDelimiterOfLastFileName();                                // DT_NONE if no GetFileName was called
 bool isLabelStart(const char *p, bool modifiersAllowed = true);
 int islabchar(char p);
 EStructureMembers GetStructMemberId(char*& p);

--- a/sjasm/sjasm.cpp
+++ b/sjasm/sjasm.cpp
@@ -374,18 +374,6 @@ namespace Options {
 		char opt[LINEMAX];
 		char val[LINEMAX];
 
-		// returns 1 when argument was processed (keyword detected, value copied into buffer)
-		// If buffer == NULL, only detection of keyword + check for non-zero "value" is done (no copy)
-		int CheckAssignmentOption(const char* keyword, char* buffer, const size_t bufferSize) {
-			if (strcmp(keyword, opt)) return 0;		// detect "keyword" (return 0 if not)
-			if (*val) {
-				if (NULL != buffer) STRCPY(buffer, bufferSize, val);
-			} else {
-				Error("no parameters found in", arg, ALL);
-			}
-			return 1;	// keyword detected, option was processed
-		}
-
 		// returns 1 when argument was processed (keyword detected, value copied into path var)
 		int CheckAssignmentOption(const char* keyword, std::filesystem::path & path) {
 			if (strcmp(keyword, opt)) return 0;		// detect "keyword" (return 0 if not)
@@ -511,10 +499,8 @@ namespace Options {
 					if (val[0]) SortSymbols = !strcmp("sort", val);
 				} else if (!strcmp(opt, "longptr")) {
 					IsLongPtr = true;
-				} else if (CheckAssignmentOption("msg", NULL, 0)) {
-					if (!*val) {
-						// nothing to do, CheckAssignmentOption already displayed error
-					} else if (!strcmp("none", val)) {
+				} else if (!strcmp(opt, "msg")) {
+					if (!strcmp("none", val)) {
 						OutputVerbosity = OV_NONE;
 						HideLogo = true;
 					} else if (!strcmp("err", val)) {

--- a/sjasm/sjasm.h
+++ b/sjasm/sjasm.h
@@ -73,16 +73,16 @@ namespace Options {
 	} SSyntax;
 
 	extern const STerminalColorSequences* tcols;
-	extern char OutPrefix[LINEMAX];
-	extern char SymbolListFName[LINEMAX];
-	extern char ListingFName[LINEMAX];
-	extern char ExportFName[LINEMAX];
-	extern char DestinationFName[LINEMAX];
-	extern char RAWFName[LINEMAX];
-	extern char UnrealLabelListFName[LINEMAX];
-	extern char CSpectMapFName[LINEMAX];
+	extern std::filesystem::path OutPrefix;
+	extern std::filesystem::path SymbolListFName;
+	extern std::filesystem::path ListingFName;
+	extern std::filesystem::path ExportFName;
+	extern std::filesystem::path DestinationFName;
+	extern std::filesystem::path RAWFName;
+	extern std::filesystem::path UnrealLabelListFName;
+	extern std::filesystem::path CSpectMapFName;
 	extern int CSpectMapPageSize;
-	extern char SourceLevelDebugFName[LINEMAX];
+	extern std::filesystem::path SourceLevelDebugFName;
 	extern bool IsDefaultSldName;
 
 	extern EOutputVerbosity OutputVerbosity;

--- a/sjasm/sjdefs.h
+++ b/sjasm/sjdefs.h
@@ -53,6 +53,7 @@
 #include <algorithm>
 #include <stack>
 #include <vector>
+#include <filesystem>
 #include <iostream>
 using std::cout;
 using std::cerr;

--- a/sjasm/sjdefs.h
+++ b/sjasm/sjdefs.h
@@ -49,6 +49,7 @@
 #endif
 
 #include <cassert>
+#include <utility>
 #include <memory>
 #include <algorithm>
 #include <stack>

--- a/sjasm/sjio.h
+++ b/sjasm/sjio.h
@@ -40,13 +40,14 @@ constexpr int INSTRUCTION_START_MARKER = -2;
 #define OUTPUT_REWIND 1
 #define OUTPUT_APPEND 2
 
+//FIXME path for archive too?
 const char* ArchiveFilename(const char* fullpathname);	// returns permanent C-string pointer to the fullpathname
 void ReleaseArchivedFilenames();	// does release all archived filenames, making all pointers invalid
-char* FilenameExtPos(char* filename, const char* initWithName = nullptr, size_t initNameMaxLength = 0);
+char* FilenameExtPos(char* filename, const char* initWithName = nullptr, size_t initNameMaxLength = 0); //FIXME get rid of this?
 void ConstructDefaultFilename(std::filesystem::path & dest, const char* ext, bool checkIfDestIsEmpty = true);
 void OpenDest(int mode = OUTPUT_TRUNCATE);
 void OpenExpFile();
-void NewDest(const char* newfilename, int mode = OUTPUT_TRUNCATE);
+void NewDest(const std::filesystem::path & newfilename, int mode = OUTPUT_TRUNCATE);
 bool FileExists(const std::filesystem::path & file_name);
 bool FileExistsCstr(const char* filename);
 FILE* GetListingFile();
@@ -60,8 +61,8 @@ void EmitBytes(const int* bytes, bool isInstructionStart = false);
 void EmitWords(const int* words, bool isInstructionStart = false);
 void EmitBlock(aint byte, aint len, bool preserveDeviceMemory = false, int emitMaxToListing = 4);
 bool DidEmitByte();		// returns true if some byte was emitted since last call to this function
-void OpenFile(const char* nfilename, bool systemPathsBeforeCurrent = false, stdin_log_t* fStdinLog = nullptr);
-void IncludeFile(const char* nfilename, bool systemPathsBeforeCurrent);
+void OpenFile(const char* nfilename, bool systemPathsBeforeCurrent = false, stdin_log_t* fStdinLog = nullptr);  //FIXME path
+void IncludeFile(const char* nfilename, bool systemPathsBeforeCurrent); //FIXME path
 void Close();
 void OpenList();
 
@@ -69,11 +70,11 @@ void OpenUnrealList();
 void ReadBufLine(bool Parse = true, bool SplitByColon = true);
 void CloseDest();
 void CloseTapFile();
-void OpenTapFile(const char * tapename, int flagbyte);
+void OpenTapFile(const std::filesystem::path & tapename, int flagbyte);
 void PrintHex(char* & dest, aint value, int nibbles);
 void PrintHex32(char* & dest, aint value);
 void PrintHexAlt(char* & dest, aint value);
-char* GetPath(const char* fname, char** filenamebegin = NULL, bool systemPathsBeforeCurrent = false);
+char* GetPath(const char* fname, char** filenamebegin = NULL, bool systemPathsBeforeCurrent = false); //FIXME path??
 
 /**
  * @brief Includes bytes of particular file into output (and virtual device memory).
@@ -83,17 +84,17 @@ char* GetPath(const char* fname, char** filenamebegin = NULL, bool systemPathsBe
  * @param length positive: bytes to include / negative: bytes to skip from end / INT_MAX: all remaining
  * @param systemPathsFirst true to search first include paths before current directory
  */
-void BinIncFile(const char* fname, aint offset, aint length, const bool systemPathsFirst);
+void BinIncFile(const char* fname, aint offset, aint length, const bool systemPathsFirst); //FIXME path
 
 int SaveRAM(FILE*, int, int);
 unsigned char MemGetByte(unsigned int address);
 unsigned int MemGetWord(unsigned int address);
-int SaveBinary(const char* fname, aint start, aint length);
-int SaveBinary3dos(const char* fname, aint start, aint length, byte type, word w2, word w3);
-int SaveBinaryAmsdos(const char* fname, aint start, aint length, word start_adr = 0, byte type = 2);
+int SaveBinary(const std::filesystem::path & fname, aint start, aint length);
+int SaveBinary3dos(const std::filesystem::path & fname, aint start, aint length, byte type, word w2, word w3);
+int SaveBinaryAmsdos(const std::filesystem::path & fname, aint start, aint length, word start_adr = 0, byte type = 2);
 bool SaveDeviceMemory(FILE* file, const size_t start, const size_t length);
-bool SaveDeviceMemory(const char* fname, const size_t start, const size_t length);
-int SaveHobeta(const char* fname, const char* fhobname, aint start, aint length);
+bool SaveDeviceMemory(const std::filesystem::path & fname, const size_t start, const size_t length);
+int SaveHobeta(const std::filesystem::path & fname, const char* fhobname, aint start, aint length);
 int ReadLineNoMacro(bool SplitByColon = true);
 int ReadLine(bool SplitByColon = true);
 EReturn ReadFile();
@@ -113,7 +114,7 @@ void SldTrackComments();
 
 /////// Breakpoints list (for different emulators)
 enum EBreakpointsFile { BPSF_UNREAL, BPSF_ZESARUX };
-void OpenBreakpointsFile(const char* filename, const EBreakpointsFile type);
+void OpenBreakpointsFile(const std::filesystem::path & filename, const EBreakpointsFile type);
 void WriteBreakpoint(const aint val);
 
 //eof sjio.h

--- a/sjasm/sjio.h
+++ b/sjasm/sjio.h
@@ -43,12 +43,12 @@ constexpr int INSTRUCTION_START_MARKER = -2;
 const char* ArchiveFilename(const char* fullpathname);	// returns permanent C-string pointer to the fullpathname
 void ReleaseArchivedFilenames();	// does release all archived filenames, making all pointers invalid
 char* FilenameExtPos(char* filename, const char* initWithName = nullptr, size_t initNameMaxLength = 0);
-const char* FilenameBasePos(const char* fullname);
-void ConstructDefaultFilename(char* dest, size_t dest_size, const char* ext, bool checkIfDestIsEmpty = true);
+void ConstructDefaultFilename(std::filesystem::path & dest, const char* ext, bool checkIfDestIsEmpty = true);
 void OpenDest(int mode = OUTPUT_TRUNCATE);
 void OpenExpFile();
 void NewDest(const char* newfilename, int mode = OUTPUT_TRUNCATE);
-bool FileExists(const char* filename);
+bool FileExists(const std::filesystem::path & file_name);
+bool FileExistsCstr(const char* filename);
 FILE* GetListingFile();
 void ListFile(bool showAsSkipped = false);
 void ListSilentOrExternalEmits();

--- a/sjasm/support.cpp
+++ b/sjasm/support.cpp
@@ -30,9 +30,14 @@
 
 #include "sjdefs.h"
 
+FILE* SJ_fopen(const std::filesystem::path & fname, const char* mode) {
+	if (nullptr == mode || fname.empty()) return nullptr;
+	return fopen(fname.string().c_str(), mode);
+}
+
 FILE* SJ_fopen(const char* fname, const char* mode) {
-	if (nullptr == fname || nullptr == mode || !*fname) return nullptr;
-	return fopen(fname, mode);
+	if (nullptr == fname) return nullptr;
+	return SJ_fopen(std::filesystem::path(fname), mode);
 }
 
 /*

--- a/sjasm/support.cpp
+++ b/sjasm/support.cpp
@@ -52,6 +52,7 @@ void SJ_GetCurrentDirectory(int whatever, char* pad) {
 	pad[0] = 0;
 	//TODO implement this one? And decide what to do with it?
 	// Will affect "--fullpath" paths if implemented correctly (as GetCurrentDirectory on windows)
+	//FIXME double-check with new std::filesystem usage, I think there may be API for this
 }
 
 static bool isAnySlash(const char c) {

--- a/sjasm/support.h
+++ b/sjasm/support.h
@@ -68,6 +68,7 @@ static_assert(0x78563412 == sj_bswap32(0x12345678), "internal error in bswap32 i
 long GetTickCount();
 #endif
 
+FILE* SJ_fopen(const std::filesystem::path & fname, const char* mode);
 FILE* SJ_fopen(const char* fname, const char* mode);
 void SJ_GetCurrentDirectory(int, char*);
 int SJ_SearchPath(const char* oudzp, const char* filename, const char* /*extension*/, int maxlen, char* nieuwzp, char** ach);

--- a/sjasm/tables.cpp
+++ b/sjasm/tables.cpp
@@ -455,7 +455,7 @@ void CLabelTable::DumpForUnreal() {
 	char ln[LINEMAX], * ep;
 	FILE* FP_UnrealList;
 	if (!FOPEN_ISOK(FP_UnrealList, Options::UnrealLabelListFName, "w")) {
-		Error("opening file for write", Options::UnrealLabelListFName, FATAL);
+		Error("opening file for write", Options::UnrealLabelListFName.string().c_str(), FATAL);
 	}
 	const int PAGE_MASK = DeviceID ? Device->GetPage(0)->Size - 1 : 0x3FFF;
 	const int ADR_MASK = Options::EmitVirtualLabels ? 0xFFFF : PAGE_MASK;
@@ -489,7 +489,7 @@ void CLabelTable::DumpForUnreal() {
 void CLabelTable::DumpForCSpect() {
 	FILE* file;
 	if (!FOPEN_ISOK(file, Options::CSpectMapFName, "w")) {
-		Error("opening file for write", Options::CSpectMapFName, FATAL);
+		Error("opening file for write", Options::CSpectMapFName.string().c_str(), FATAL);
 	}
 	const int CSD_PAGE_SIZE = Options::CSpectMapPageSize;
 	const int CSD_PAGE_MASK = CSD_PAGE_SIZE - 1;
@@ -541,7 +541,7 @@ void CLabelTable::DumpForCSpect() {
 void CLabelTable::DumpSymbols() {
 	FILE* symfp;
 	if (!FOPEN_ISOK(symfp, Options::SymbolListFName, "w")) {
-		Error("opening file for write", Options::SymbolListFName, FATAL);
+		Error("opening file for write", Options::SymbolListFName.string().c_str(), FATAL);
 	}
 	const auto order = getDumpOrder(symbols);
 	for (const symbol_map_t::key_type& name: order) {

--- a/tests/lua_examples/trivial/lua_coverage2.lst
+++ b/tests/lua_examples/trivial/lua_coverage2.lst
@@ -13,7 +13,7 @@ lua_coverage2.asm(7): error: Unexpected: @
 11    0001 ~                    assert(false == zx.trdimage_add_file("1.trd",nil,0x1234,1))
 12    0001 ~                    assert(false == zx.save_snapshot_sna(nil,0x8000))
 13    0001 ~                    zx.save_snapshot_sna("1.sna")   -- bad argument #2, exits this script
-lua_coverage2.asm(10): error: [LUA] opening file for write
+lua_coverage2.asm(10): error: [LUA] opening file for write:
 lua_coverage2.asm(12): error: [LUA] [SAVESNA] Only for real device emulation mode.
 lua_coverage2.asm(13): error: [LUA] bad argument #2 to 'save_snapshot_sna' (number expected, got no value)
 14    0001                  ENDLUA

--- a/tests/misc/env_SJASMPLUSOPTS/env_normal2.cli
+++ b/tests/misc/env_SJASMPLUSOPTS/env_normal2.cli
@@ -2,7 +2,7 @@
 # this variant of "normal" test has a twist, it puts the ASM source also into ENVVAR (twice!)
 # and doubles also the regular line, so the same source is assembled four times in total
 # There are also multiple invalid/unused options just to exercise option parsing in sjasm.cpp
-SJASMPLUSOPTS="-DFLAGSDEFINE=defined $file_asm --dirbol $file_asm --unknownOptionToTestError -i --dos866 -D" \
+SJASMPLUSOPTS="-DFLAGSDEFINE=defined $file_asm --dirbol $file_asm --unknownOptionToTestError -i --dos866 --exp= -D" \
 NO_COLOR=1 \
 $MEMCHECK "$EXE" --nologo --msg=lstlab --fullpath "${options[@]}" "$file_asm" "$file_asm" 2> "${dst_base}.lst"
 last_result=$?

--- a/tests/misc/env_SJASMPLUSOPTS/env_normal2.msglst
+++ b/tests/misc/env_SJASMPLUSOPTS/env_normal2.msglst
@@ -1,5 +1,6 @@
 error: unrecognized option: --unknownOptionToTestError
 error: no include path found in: -i
+error: no parameters found in: --exp=
 error: no parameters found in: -D
 # file opened: env_normal2.asm
 1     0000 00               DB 0

--- a/tests/misc/trd/savetrd4.asm
+++ b/tests/misc/trd/savetrd4.asm
@@ -162,3 +162,10 @@
     SAVETRD "savetrd4.trd",&"333.C",#4000,12032 ; error: file not found (even in full catalog)
     ; disk free 0 sec., 0 erased files
 
+    SAVETRD "savetrd4.trd","",#4000,100             ; error: no filename
+    SAVETRD "savetrd4.trd",,#4000,100               ; error: no filename
+    SAVETRD "savetrd4.trd","NOPARAM.C"              ; error: no address
+    SAVETRD "savetrd4.trd","NOPARAM.C",,100         ; error: no address
+    SAVETRD "savetrd4.trd","NOPARAM.C",#4000        ; error: no length
+    SAVETRD "savetrd4.trd","NOPARAM.C",#4000,0      ; error: bad length
+    SAVETRD "savetrd4.trd","NOPARAM.C",#4000,#FF01  ; error: bad length

--- a/tests/misc/trd/savetrd4.lst
+++ b/tests/misc/trd/savetrd4.lst
@@ -169,6 +169,21 @@ savetrd4.asm(162): error: TRD image does not have a specified file to add data: 
 162   4000                  SAVETRD "savetrd4.trd",&"333.C",#4000,12032 ; error: file not found (even in full catalog)
 163   4000                  ; disk free 0 sec., 0 erased files
 164   4000
+savetrd4.asm(165): error: [SAVETRD] No filename: SAVETRD "savetrd4.trd","",#4000,100
+165   4000                  SAVETRD "savetrd4.trd","",#4000,100             ; error: no filename
+savetrd4.asm(166): error: [SAVETRD] No filename: SAVETRD "savetrd4.trd",,#4000,100
+166   4000                  SAVETRD "savetrd4.trd",,#4000,100               ; error: no filename
+savetrd4.asm(167): error: [SAVETRD] Syntax error. No address: SAVETRD "savetrd4.trd","NOPARAM.C"
+167   4000                  SAVETRD "savetrd4.trd","NOPARAM.C"              ; error: no address
+savetrd4.asm(168): error: zx.trdimage_add_file: start address must be in 0000..FFFF range: SAVETRD "savetrd4.trd","NOPARAM.C",,100
+168   4000                  SAVETRD "savetrd4.trd","NOPARAM.C",,100         ; error: no address
+savetrd4.asm(169): error: [SAVETRD] Syntax error. No length: SAVETRD "savetrd4.trd","NOPARAM.C",#4000
+169   4000                  SAVETRD "savetrd4.trd","NOPARAM.C",#4000        ; error: no length
+savetrd4.asm(170): error: zx.trdimage_add_file: length must be in 0001..FF00 range: SAVETRD "savetrd4.trd","NOPARAM.C",#4000,0
+170   4000                  SAVETRD "savetrd4.trd","NOPARAM.C",#4000,0      ; error: bad length
+savetrd4.asm(171): error: zx.trdimage_add_file: length must be in 0001..FF00 range: SAVETRD "savetrd4.trd","NOPARAM.C",#4000,#FF01
+171   4000                  SAVETRD "savetrd4.trd","NOPARAM.C",#4000,#FF01  ; error: bad length
+172   4000
 # file closed: savetrd4.asm
 
 Value    Label

--- a/tests/test build script and options/nonCodeOptions/optionMsg_empty1.msglst
+++ b/tests/test build script and options/nonCodeOptions/optionMsg_empty1.msglst
@@ -1,4 +1,4 @@
-error: no parameters found in: --msg=
+error: unexpected parameter in: --msg=
 # file opened: optionMsg_empty1.asm
 1     0000 00           nn: nop
 optionMsg_empty1.asm(2): warning: value 0x7761726E is truncated to 8bit value: 0x6E

--- a/tests/test build script and options/nonCodeOptions/optionMsg_empty2.msglst
+++ b/tests/test build script and options/nonCodeOptions/optionMsg_empty2.msglst
@@ -1,4 +1,4 @@
-error: no parameters found in: --msg
+error: unexpected parameter in: --msg
 # file opened: optionMsg_empty2.asm
 1     0000 00           nn: nop
 optionMsg_empty2.asm(2): warning: value 0x7761726E is truncated to 8bit value: 0x6E


### PR DESCRIPTION
First part of #240 - migrating to std::filesystem goodies, parsing source and saving output files is now fully `std::filesystem::path`, include directories are checked by std::filesystem too.

Opening files (for various includes) is still degrading path to strings and operating upon them with old implementation, I have some idea how to rewrite it, starting with filename archive becoming `std::set<...::path>` and returning iterators to it (dereference those to get path/string), maybe even opening the file for "rb" automatically.

Needs more research and reshuffling of current code, so this will come as "part two".

But merging this part already to get working windows builds on master branch, this is technically fully working prod-quality version, as it should be with master branch head.