### PR TITLE
more --fullpath options

### DIFF
--- a/docs/documentation.xml
+++ b/docs/documentation.xml
@@ -214,6 +214,7 @@
 - include paths which can't be opened before assembling are now reported in error message
 - include paths which start with literal tilde '~' are reported in error message
 - include options <link linkend="s_cli">`-i, -I, --inc`</link> can take path from next CLI argument (new recommended syntax)
+- option <link linkend="s_cli">`--fullpath`</link> has now three states including full absolute paths
 - added Amstrad CPC device <link linkend="po_device">AMSTRADCPCPLUS</link> - by Laurent Carlier
 - added Amstrad CPC+ <link linkend="po_savecpr">`SAVECPR`</link> to save CPR cartridge - by Laurent Carlier
 - ZX Next CSpect emulator v2.19.9.1: `break` opcode changed to `FD 00`
@@ -497,9 +498,8 @@
   Note: "lst" or "lstlab" will turn STDERR into listing file (this will clash with
   `--lst`, use only one of the options) and some diagnostic messages of "all"
   are omitted, as they are not part of listing files. "lstlab" does sort symbols.
-  --fullpath               Show full path to file in errors
-  Note: the "fullpath" starts from current working directory, not from file system
-		root (the MS_VS build was fixed to behave this way since v1.15.0)
+  --fullpath[=on|rel|off]  Input file paths: full | CWD relative | name only (*)
+  Note: --fullpath without value is "rel" (relative to current working directory)
   --color=[on|off|auto]    Enable or disable ANSI coloring of warnings/errors
   Note: auto detection checks for existence of environment variable TERM, and its
 		content is scanned for sub-string "color" (like "xterm-256color")

--- a/sjasm/directives.cpp
+++ b/sjasm/directives.cpp
@@ -610,10 +610,10 @@ static void dirINCHOB() {
 
 	FILE* ff;
 	if (!FOPEN_ISOK(ff, fnaam.full, "rb")) {
-		Error("[INCHOB] Error opening file", fnaam.fullStr.c_str(), FATAL);
+		Error("[INCHOB] Error opening file", fnaam.str.c_str(), FATAL);
 	}
 	if (fseek(ff, 0x0b, 0) || 2 != fread(len, 1, 2, ff)) {
-		Error("[INCHOB] Hobeta file has wrong format", fnaam.fullStr.c_str(), FATAL);
+		Error("[INCHOB] Hobeta file has wrong format", fnaam.str.c_str(), FATAL);
 	}
 	fclose(ff);
 	if (length == -1) {

--- a/sjasm/io_nex.cpp
+++ b/sjasm/io_nex.cpp
@@ -299,7 +299,7 @@ void SBmpFile::close() {
 
 bool SBmpFile::open(fullpath_ref_t bmpIn) {
 	if (!FOPEN_ISOK(bmp, bmpIn.full, "rb")) {
-		Error("[SAVENEX] Error opening file", bmpIn.fullStr.c_str(), SUPPRESS);
+		Error("[SAVENEX] Error opening file", bmpIn.str.c_str(), SUPPRESS);
 		return false;
 	}
 	palBuffer = new byte[4*PALETTE_SIZE];
@@ -324,7 +324,7 @@ bool SBmpFile::open(fullpath_ref_t bmpIn) {
 		40 != header2Size || 1 != colorPlanes || 8 != bpp || 0 != compressionType)
 	{
 		Error("[SAVENEX] BMP file is not in expected format (uncompressed, 8bpp, 40B BITMAPINFOHEADER header)",
-				bmpIn.fullStr.c_str(), SUPPRESS);
+				bmpIn.str.c_str(), SUPPRESS);
 		close();
 		return false;
 	}
@@ -752,7 +752,7 @@ static void dirNexScreenBmp() {
 	SBmpFile bmp;
 	bool bmpOpened = bmp.open(bmpIn);
 	if (bmpOpened && other == bmp.type) {
-		Error("[SAVENEX] BMP file is not 256x192, 128x96, 320x256 or 640x256", bmpIn.fullStr.c_str(), SUPPRESS);
+		Error("[SAVENEX] BMP file is not 256x192, 128x96, 320x256 or 640x256", bmpIn.str.c_str(), SUPPRESS);
 		bmpOpened = false;
 	}
 	if (!bmpOpened) return;
@@ -1041,7 +1041,7 @@ static void dirNexClose() {
 	if (appendIn.full.has_filename()) {	// some append file requested, try to copy its content at tail of NEX
 		FILE* appendF = nullptr;
 		if (!FOPEN_ISOK(appendF, appendIn.full, "rb")) {
-			Error("[SAVENEX] Error opening append file", appendIn.fullStr.c_str(), SUPPRESS);
+			Error("[SAVENEX] Error opening append file", appendIn.str.c_str(), SUPPRESS);
 		} else {
 			static constexpr int copyBufSize = 0x4000;
 			byte* copyBuffer = new byte[copyBufSize];

--- a/sjasm/io_trd.cpp
+++ b/sjasm/io_trd.cpp
@@ -494,9 +494,9 @@ int TRD_PrepareIncFile(fullpath_ref_t trd, const char* filename, aint & offset, 
 	// read 9 sectors of disk into "trdHead" (contains root directory catalog and disk info data)
 	STrdHead trdHead;
 	FILE* ff = SJ_fopen(trd.full, "rb");
-	if (nullptr == ff) return ReturnWithError("[INCTRD] Error opening file", trd.fullStr.c_str(), ff);
+	if (nullptr == ff) return ReturnWithError("[INCTRD] Error opening file", trd.str.c_str(), ff);
 	if (!trdHead.readFromFile(ff)) {
-		return ReturnWithError("TRD image read error", trd.fullStr.c_str(), ff);
+		return ReturnWithError("TRD image read error", trd.str.c_str(), ff);
 	}
 	fclose(ff);
 	ff = nullptr;

--- a/sjasm/lua_sjasm.cpp
+++ b/sjasm/lua_sjasm.cpp
@@ -98,7 +98,7 @@ static int addLuaSourcePositions() {
 			levelErrorPos.line += ar.currentline;
 		} else {
 			fullpath_ref_t archivedFname = GetInputFile(delim_string_t(ar.short_src, DT_COUNT));
-			levelErrorPos.newFile(archivedFname.fullStr.c_str());
+			levelErrorPos.newFile(archivedFname.str.c_str());
 			levelErrorPos.line = ar.currentline;
 		}
 		luaPosTemp.push_back(levelErrorPos);
@@ -134,7 +134,7 @@ static TextFilePos lua_impl_splitLuaErrorMessage(const char*& LuaError) {
 	} else {
 		// standalone script, use file name and line number as is (if provided by lua error)
 		fullpath_ref_t archFname = GetInputFile(delim_string_t(std::string(LuaError, colonPos), DT_COUNT));
-		luaErrorPos.newFile(archFname.fullStr.c_str());
+		luaErrorPos.newFile(archFname.str.c_str());
 		luaErrorPos.line = lineNumber;
 	}
 
@@ -529,10 +529,11 @@ void dirINCLUDELUA() {
 	}
 	fullpath_ref_t file_in = GetInputFile(lp);
 	if (!FileExists(file_in.full)) {
-		Error("[INCLUDELUA] File doesn't exist", file_in.fullStr.c_str(), EARLY);
+		Error("[INCLUDELUA] File doesn't exist", file_in.str.c_str(), EARLY);
 	} else {
 		extraErrorWarningPrefix = lua_err_prefix;
-		if (luaL_dofile(LUA, file_in.fullStr.c_str())) {
+		// Use relative-to-launch-dir filename for open to get reasonable source-pos-string in errors
+		if (luaL_dofile(LUA, file_in.full.lexically_proximate(LaunchDirectory).string().c_str())) {
 			lua_impl_showLoadError(EARLY);
 		}
 		extraErrorWarningPrefix = nullptr;

--- a/sjasm/sjasm.cpp
+++ b/sjasm/sjasm.cpp
@@ -61,7 +61,7 @@ static void PrintHelpMain() {
 	_COUT "  --nologo                 Do not show startup message" _ENDL;
 	_COUT "  --msg=[all|war|err|none|lst|lstlab]" _ENDL;
 	_COUT "                           Stderr messages verbosity (\"all\" is default)" _ENDL;
-	_COUT "  --fullpath               Show full path to file in errors" _ENDL;
+	_COUT "  --fullpath[=on|rel|off]  Input file paths: full | CWD relative | name only" _ENDL;
 	_COUT "  --color=[on|off|auto]    Enable or disable ANSI coloring of warnings/errors" _ENDL;
 	_COUT " Other:" _ENDL;
 	_COUT "  -D<NAME>[=<value>] or --define <NAME>[=<value>]" _ENDL;
@@ -539,7 +539,15 @@ namespace Options {
 					CheckAssignmentOption("raw", RAWFName) ) {
 					// was proccessed inside CheckAssignmentOption function
 				} else if (!strcmp(opt, "fullpath")) {
-					FileVerbosity = FNAME_LAUNCH_REL;
+					if (!strcmp("on", val)) {
+						FileVerbosity = FNAME_ABSOLUTE;
+					} else if (!val[0] || !strcmp("rel", val)) {
+						FileVerbosity = FNAME_LAUNCH_REL;
+					} else if (!strcmp("off", val)) {
+						FileVerbosity = FNAME_BASE;
+					} else {
+						Error("invalid --fullpath setting (use: on|rel|off)", val, ALL);
+					}
 				} else if (!strcmp(opt, "color")) {
 					if (!strcmp("on", val)) {
 						SetTerminalColors(true);

--- a/sjasm/sjasm.cpp
+++ b/sjasm/sjasm.cpp
@@ -110,11 +110,11 @@ namespace Options {
 	bool IsDefaultSldName = false;
 
 	EOutputVerbosity OutputVerbosity = OV_ALL;
-	bool IsLabelTableInListing = 0;
+	bool IsLabelTableInListing = false;
 	bool IsDefaultListingName = false;
-	bool IsShowFullPath = 0;
+	bool IsShowFullPath = false;
 	bool AddLabelListing = false;
-	bool HideLogo = 0;
+	bool HideLogo = false;
 	bool ShowHelp = false;
 	bool ShowHelpWarnings = false;
 	bool ShowVersion = false;
@@ -244,7 +244,6 @@ source_positions_t::size_type smartSmcIndex;
 uint32_t maxlin = 0;
 aint CurAddress = 0, CompiledCurrentLine = 0, LastParsedLabelLine = 0, PredefinedCounter = 0;
 aint destlen = 0, size = -1L, comlin = 0;
-std::filesystem::path CurrentDirectory {};
 
 char* vorlabp=NULL, * macrolabp=NULL, * LastParsedLabel=NULL;
 std::stack<SRepeatStack> RepeatStack;
@@ -540,7 +539,7 @@ namespace Options {
 					CheckAssignmentOption("raw", RAWFName) ) {
 					// was proccessed inside CheckAssignmentOption function
 				} else if (!strcmp(opt, "fullpath")) {
-					IsShowFullPath = 1;
+					IsShowFullPath = true;
 				} else if (!strcmp(opt, "color")) {
 					if (!strcmp("on", val)) {
 						SetTerminalColors(true);
@@ -647,8 +646,6 @@ namespace Options {
 
 // == end of UnitTest++ part ====================================================================
 
-static char launch_directory[MAX_PATH];
-
 #ifdef WIN32
 int main(int argc, char* argv[]) {
 #else
@@ -672,8 +669,8 @@ int main(int argc, char **argv) {
 	long dwStart = GetTickCount();
 
 	// get current directory
-	SJ_GetCurrentDirectory(MAX_PATH, launch_directory);
-	CurrentDirectory = launch_directory;
+	LaunchDirectory = std::filesystem::current_path();
+	CurrentDirectory = LaunchDirectory;
 
 	Options::COptionsParser optParser;
 	char* envFlags = std::getenv("SJASMPLUSOPTS");

--- a/sjasm/sjasm.cpp
+++ b/sjasm/sjasm.cpp
@@ -112,7 +112,7 @@ namespace Options {
 	EOutputVerbosity OutputVerbosity = OV_ALL;
 	bool IsLabelTableInListing = false;
 	bool IsDefaultListingName = false;
-	bool IsShowFullPath = false;
+	EFileVerbosity FileVerbosity = FNAME_BASE;
 	bool AddLabelListing = false;
 	bool HideLogo = false;
 	bool ShowHelp = false;
@@ -539,7 +539,7 @@ namespace Options {
 					CheckAssignmentOption("raw", RAWFName) ) {
 					// was proccessed inside CheckAssignmentOption function
 				} else if (!strcmp(opt, "fullpath")) {
-					IsShowFullPath = true;
+					FileVerbosity = FNAME_LAUNCH_REL;
 				} else if (!strcmp(opt, "color")) {
 					if (!strcmp("on", val)) {
 						SetTerminalColors(true);
@@ -736,7 +736,8 @@ int main(int argc, char **argv) {
 		_CERR logo _ENDL;
 	}
 
-	if (!Options::IsShowFullPath && (Options::IsDefaultSldName || Options::SourceLevelDebugFName.has_filename())) {
+	if ((Options::FNAME_BASE == Options::FileVerbosity) &&
+		(Options::IsDefaultSldName || Options::SourceLevelDebugFName.has_filename())) {
 		Warning("missing  --fullpath  with  --sld  may produce incomplete file paths.", NULL, W_EARLY);
 	}
 

--- a/sjasm/sjasm.h
+++ b/sjasm/sjasm.h
@@ -167,7 +167,6 @@ extern aint destlen, size, comlin;
 extern char* vorlabp, * macrolabp, * LastParsedLabel;
 
 enum EEncoding { ENCDOS, ENCWIN };
-extern std::filesystem::path CurrentDirectory;
 
 void ExitASM(int p);
 extern CStringsList* lijstp;

--- a/sjasm/sjasm.h
+++ b/sjasm/sjasm.h
@@ -36,6 +36,9 @@ namespace Options {
 	// which lines should made it into listing: all, active (not skipped by IF false), only-if-has-machine-code
 	enum ELstType { LST_T_ALL, LST_T_ACTIVE, LST_T_MC_ONLY };
 
+	// how file names are displayed in errors, listings, SLD, ...: just base name, relative to launch dir, full absolute path
+	enum EFileVerbosity { FNAME_BASE, FNAME_LAUNCH_REL, FNAME_ABSOLUTE };
+
 	typedef struct STerminalColorSequences {
 		const char * end, * display, * warning, * error, * bold;
 	} STerminalColorSequences;
@@ -88,7 +91,7 @@ namespace Options {
 	extern EOutputVerbosity OutputVerbosity;
 	extern bool IsLabelTableInListing;
 	extern bool IsDefaultListingName;
-	extern bool IsShowFullPath;
+	extern EFileVerbosity FileVerbosity;
 	extern bool AddLabelListing;
 	extern bool NoDestinationFile;
 	extern SSyntax syx;

--- a/sjasm/sjio.cpp
+++ b/sjasm/sjio.cpp
@@ -36,6 +36,9 @@ static const std::filesystem::path EMPTY_PATH{""};
 static constexpr char pathBadSlash = '\\';
 static constexpr char pathGoodSlash = '/';
 
+std::filesystem::path LaunchDirectory {};
+std::filesystem::path CurrentDirectory {};
+
 int ListAddress;
 
 static constexpr int LIST_EMIT_BYTES_BUFFER_SIZE = 1024 * 64;

--- a/sjasm/sjio.h
+++ b/sjasm/sjio.h
@@ -42,22 +42,21 @@ constexpr int INSTRUCTION_START_MARKER = -2;
 extern std::filesystem::path LaunchDirectory;
 extern std::filesystem::path CurrentDirectory;
 
-// input file archiving helper struct (holding instance of full and base name strings to keep c_str() pointers valid)
+// input file archiving helper struct (holding instance name string to keep c_str() pointers valid)
 struct SInputFile {
   const std::filesystem::path full;
-  const std::string fullStr;
-  const std::string baseStr;
+  const std::string str;
 
-  SInputFile(const std::filesystem::path && fullName) :
-                  full(std::move(fullName)),
-                  fullStr(SJ_force_slash(full.lexically_proximate(LaunchDirectory)).string()),
-                  baseStr(full.filename().string()) {
-  }
+  SInputFile(const std::filesystem::path && fullName) : full(std::move(fullName)), str(InitStr()) {}
 
-  SInputFile(int) : full(), fullStr("<stdin>"), baseStr("<stdin>") {} // special const. for stdin
+  SInputFile(int) : full(), str("<stdin>") {} // special const. for stdin
 
+private:
   SInputFile() = delete;
   SInputFile(const SInputFile &) = delete;
+  SInputFile& operator=(const SInputFile &) = delete;
+
+  std::string InitStr();    // convert `full` path into string based on Options::FileVerbosity
 };
 
 using fullpath_ref_t = const SInputFile &;

--- a/sjasm/sjio.h
+++ b/sjasm/sjio.h
@@ -39,6 +39,9 @@ constexpr int INSTRUCTION_START_MARKER = -2;
 #define OUTPUT_REWIND 1
 #define OUTPUT_APPEND 2
 
+extern std::filesystem::path LaunchDirectory;
+extern std::filesystem::path CurrentDirectory;
+
 // input file archiving helper struct (holding instance of full and base name strings to keep c_str() pointers valid)
 struct SInputFile {
   const std::filesystem::path full;
@@ -47,7 +50,7 @@ struct SInputFile {
 
   SInputFile(const std::filesystem::path && fullName) :
                   full(std::move(fullName)),
-                  fullStr(full.string()),
+                  fullStr(SJ_force_slash(full.lexically_proximate(LaunchDirectory)).string()),
                   baseStr(full.filename().string()) {
   }
 

--- a/sjasm/support.cpp
+++ b/sjasm/support.cpp
@@ -49,13 +49,6 @@ FILE* SJ_fopen(const std::filesystem::path & fname, const char* mode) {
 	return fopen(fname.string().c_str(), mode);
 }
 
-void SJ_GetCurrentDirectory(int whatever, char* pad) {
-	pad[0] = 0;
-	//TODO implement this one? And decide what to do with it?
-	// Will affect "--fullpath" paths if implemented correctly (as GetCurrentDirectory on windows)
-	//FIXME double-check with new std::filesystem usage, I think there may be API for this
-}
-
 #ifndef WIN32
 
 long GetTickCount() {

--- a/sjasm/support.h
+++ b/sjasm/support.h
@@ -72,7 +72,6 @@ long GetTickCount();
 
 void SJ_FixSlashes(delim_string_t & str, bool do_warning = true); // convert backslashes, can produce warning
 FILE* SJ_fopen(const std::filesystem::path & fname, const char* mode);
-void SJ_GetCurrentDirectory(int, char*);
 
 // FILE* dbg_fopen(const char* fname, const char* modes);
 

--- a/tests/test build script and options/nonCodeOptions/optionFullpath.asm
+++ b/tests/test build script and options/nonCodeOptions/optionFullpath.asm
@@ -1,0 +1,3 @@
+    ; test --fullpath results in listing file
+    INCLUDE "optionFullpath/optionFullpath.i.asm"
+    ASSERT 0    ; for error reporting file pos

--- a/tests/test build script and options/nonCodeOptions/optionFullpath.cli
+++ b/tests/test build script and options/nonCodeOptions/optionFullpath.cli
@@ -1,0 +1,17 @@
+## run sjasmplus with all --fulpath posssible options "--fullpath=off|rel|on" and uknown value
+LANG=C $MEMCHECK "$EXE" --nologo --msg=lstlab                "${options[@]}" 2> "${dst_base}.1a.lst" "$file_asm"
+LANG=C $MEMCHECK "$EXE" --nologo --msg=lstlab --fullpath=off "${options[@]}" 2> "${dst_base}.1b.lst" "$file_asm"
+LANG=C $MEMCHECK "$EXE" --nologo --msg=lstlab --fullpath=rel "${options[@]}" 2> "${dst_base}.2a.lst" "$file_asm"
+LANG=C $MEMCHECK "$EXE" --nologo --msg=lstlab --fullpath     "${options[@]}" 2> "${dst_base}.2b.lst" "$file_asm"
+LANG=C $MEMCHECK "$EXE" --nologo --msg=lstlab --fullpath=on  "${options[@]}" 2> "${dst_base}.3.lst"  "$file_asm"
+LANG=C $MEMCHECK "$EXE" --nologo --msg=lstlab --fullpath=xxx "${options[@]}" 2> "${dst_base}.4.lst"  "$file_asm"
+# check that 1a == 1b, 2a == 2b, and 1 != 2 != 3 != 4 (not checking lst content, differences are enough to pass)
+diff "${dst_base}.1a.lst" "${dst_base}.1b.lst" && \
+diff "${dst_base}.2a.lst" "${dst_base}.2b.lst" && \
+! diff -q "${dst_base}.1a.lst" "${dst_base}.2a.lst" > /dev/null && \
+! diff -q "${dst_base}.1a.lst" "${dst_base}.3.lst" > /dev/null && \
+! diff -q "${dst_base}.1a.lst" "${dst_base}.4.lst" > /dev/null && \
+! diff -q "${dst_base}.2a.lst" "${dst_base}.3.lst" > /dev/null && \
+! diff -q "${dst_base}.2a.lst" "${dst_base}.4.lst" > /dev/null && \
+! diff -q "${dst_base}.3.lst" "${dst_base}.4.lst" > /dev/null
+last_result=$?

--- a/tests/test build script and options/nonCodeOptions/optionFullpath/optionFullpath.i.asm
+++ b/tests/test build script and options/nonCodeOptions/optionFullpath/optionFullpath.i.asm
@@ -1,0 +1,2 @@
+    ret
+    ASSERT 0    ; for error reporting file pos


### PR DESCRIPTION
Add more fine-tuned `--fullpath` option providing both "relative to launch-dir" and "absolute full path" ways.