### PR TITLE
labels: add physical address/page operators $$$label and $$$$label, c…

### DIFF
--- a/docs/documentation.xml
+++ b/docs/documentation.xml
@@ -210,6 +210,7 @@
             <listitem>
               <synopsis>
 - Added <link linkend="s_sizeof_labels">`SIZEOF`</link> operator for labels
+- Added <link linkend="op_label_ph_val">`$$$label`</link> and <link linkend="op_label_ph_page">`$$$$label`</link> operators for labels
 - refactoring device - page numbering, error values changed from -1 to 0x7F00+ (<link linkend="lua_sj_get_page_at">`get_page_at`</link>)
 - small internal bug fixes (edge case with negative blocks, `_` glue, SLD export of EQU adjusted)
 - CI: binary reproducibility tested weekly
@@ -1093,7 +1094,10 @@ $c     hexadecimal
 	  where the "label" was defined (only regular labels have meaningful value, labels defined
 	  under DISP mode may return the page specified in DISP itself, EQU/DEFL/... will produce mostly
 	  irrelevant values). '$$$' and '$$$$' can be used inside DISP block to retrieve the "physical"
-	  memory address and page (where the displaced machine code is written to). '{address}' can be used
+	  memory address and page (where the displaced machine code is written to). '$$$label' and '$$$$label'
+      can be used to read "physical" address and page of any label (for non-regular labels like EQU, DEFL
+      or SMC-offset label the "physical" address is address where the label was defined (see <ulink url="https://github.com/z00m128/sjasmplus/blob/master/tests/devices/get_label_physical_memory_operators.asm">
+      get_label_physical_memory_operators.asm</ulink> test for edge cases and details). '{address}' can be used
       to read WORD from virtual device memory (correct value is read only in last pass of assembling,
 	  in early passes the zero value is always returned), '{b address}' reads only BYTE.</para>
 
@@ -1160,6 +1164,8 @@ $$$    $$$       <indexterm id="op_dollar3"><primary>$$$</primary></indexterm>"p
 $$$$   $$$$      <indexterm id="op_dollar4"><primary>$$$$</primary></indexterm>"physical" memory page (inside DISP block in virtual device mode)
 label  label     value of label (aka symbol), usually memory address
 $$lab  $$lab     <indexterm id="op_label_page"><primary>$$label</primary></indexterm>page of "lab" label (in virtual device mode)
+$$$lab $$$lab    <indexterm id="op_label_ph_val"><primary>$$$label</primary></indexterm>"physical" address of "lab" label
+$$$$lb $$$$lb    <indexterm id="op_label_ph_page"><primary>$$$$label</primary></indexterm>"physical" memory page of "lb" label
 {}     {x}       <indexterm id="op_read_word"><primary>{..}</primary></indexterm>reads WORD from address x (in virtual device mode, in last pass)
 {b}    {b x}     <indexterm id="op_read_byte"><primary>{b ..}</primary></indexterm>reads BYTE from address x (in virtual device mode, in last pass)
 </programlisting></para>

--- a/sjasm/parser.cpp
+++ b/sjasm/parser.cpp
@@ -81,6 +81,12 @@ static int ParseExpPrim(char*& p, aint& nval) {
 		Warning("?<symbol> operator is deprecated and will be removed in v2.x", p);
 		++p;
 		return GetLabelValue(p, nval);
+	} else if ('$' == p[0] && '$' == p[1] && '$' == p[2] && '$' == p[3] && isLabelStart(p + 4)) {
+		p += 4;								// $$$$label variant returns physical page
+		return GetLabelPhPage(p, nval);
+	} else if ('$' == p[0] && '$' == p[1] && '$' == p[2] && isLabelStart(p + 3)) {
+		p += 3;								// $$$label variant returns physical value
+		return GetLabelPhValue(p, nval);
 	} else if (DISP_NONE != PseudoORG && '$' == p[0] && '$' == p[1] && '$' == p[2]) {
 		if ('$' == p[3]) {		// "$$$$" operator to get physical memory page inside DISP block
 			p += 4;

--- a/sjasm/tables.cpp
+++ b/sjasm/tables.cpp
@@ -300,6 +300,18 @@ bool GetLabelValue(char*& p, aint& val) {
 	return !getLabel_invalidName;
 }
 
+bool GetLabelPhPage(char*& p, aint& val) {
+	SLabelTableEntry* labelEntry = GetLabel(p);
+	val = labelEntry ? labelEntry->ph_page : LABEL_PAGE_UNDEFINED;
+	return !getLabel_invalidName;		// true even when not found, but valid label name
+}
+
+bool GetLabelPhValue(char*& p, aint& val) {
+	SLabelTableEntry* labelEntry = GetLabel(p);
+	val = labelEntry ? labelEntry->ph_value : 0;	// no relocation logic for ph_value
+	return !getLabel_invalidName;		// true even when not found, but valid label name
+}
+
 bool GetLabelSize(char*& p, aint& val) {
 	// if symbol is found, add "sizeof" trait, if not found, insert placeholder with "sizeof" trait
 	SLabelTableEntry* labelEntry = GetLabel(p, LABEL_HAS_SIZE);

--- a/sjasm/tables.h
+++ b/sjasm/tables.h
@@ -73,6 +73,8 @@ extern char* PreviousIsLabel;
 bool LabelExist(char*& p, aint& val);
 bool GetLabelPage(char*& p, aint& val);
 bool GetLabelValue(char*& p, aint& val);
+bool GetLabelPhPage(char*& p, aint& val);
+bool GetLabelPhValue(char*& p, aint& val);
 bool GetLabelSize(char*& p, aint& val);
 int GetTemporaryLabelValue(char*& op, aint& val, bool requireUnderscore = false);
 

--- a/tests/devices/get_label_physical_memory_operators.asm
+++ b/tests/devices/get_label_physical_memory_operators.asm
@@ -1,0 +1,90 @@
+    DEVICE ZXSPECTRUMNEXT
+;;; labels now track their "physical" position as well as regular/displaced address
+    MMU $0000 $E000, 30, $4000-2
+orgL1:
+.local:                 ; regular label, page 31
+    DB      'A'
+    DISP    $C000-1, 41
+dispL1:                 ; disp lavel, disp page 41, physical still page 31 (last byte)
+.local:
+    DB      'B'
+dispL2:                 ; goes into page 32 physically, but has enforced DISP page 41
+.local:
+    DB      'C'
+    ENT
+orgL2:
+.local:
+    DB      'D'
+    ; regular labels should report same value/page also for "physical" address
+    ASSERT  $3FFE == orgL1          && 31 == $$orgL1        && $3FFE == $$$orgL1        && 31 == $$$$orgL1
+    ASSERT  $3FFE == orgL1.local    && 31 == $$orgL1.local  && $3FFE == $$$orgL1.local  && 31 == $$$$orgL1.local
+    ASSERT  $BFFF == dispL1         && 41 == $$dispL1       && $3FFF == $$$dispL1       && 31 == $$$$dispL1
+    ASSERT  $BFFF == dispL1.local   && 41 == $$dispL1.local && $3FFF == $$$dispL1.local && 31 == $$$$dispL1.local
+    ASSERT  $C000 == dispL2         && 41 == $$dispL2       && $4000 == $$$dispL2       && 32 == $$$$dispL2
+    ASSERT  $C000 == dispL2.local   && 41 == $$dispL2.local && $4000 == $$$dispL2.local && 32 == $$$$dispL2.local
+    ASSERT  $4001 == orgL2          && 32 == $$orgL2        && $4001 == $$$orgL2        && 32 == $$$$orgL2
+    ASSERT  $4001 == orgL2.local    && 32 == $$orgL2.local  && $4001 == $$$orgL2.local  && 32 == $$$$orgL2.local
+
+;;; EQU tracks program counter where it was defined in the physical page/address
+;;; just emerging behaviour out of implementation, no deep idea behind it, probably useless
+    DISP $D000
+Equ1        EQU     $EE01           ; picks up page from $EE01 value itself, ie. 37
+Equ2        EQU     $EE02, 51       ; explicit equ page
+    ENT
+    DB      'E'
+    DISP $D000, 61
+Equ3        EQU     $EE03           ; picks up page from explicit DISP page 61
+Equ4        EQU     $EE04, 52       ; explicit equ page
+    ENT
+    DB      'F'
+    ASSERT  $EE01 == Equ1           && 37 == $$Equ1         && $4002 == $$$Equ1         && 32 == $$$$Equ1
+    ASSERT  $EE02 == Equ2           && 51 == $$Equ2         && $4002 == $$$Equ2         && 32 == $$$$Equ2
+    ASSERT  $EE03 == Equ3           && 61 == $$Equ3         && $4003 == $$$Equ3         && 32 == $$$$Equ3
+    ASSERT  $EE04 == Equ4           && 52 == $$Equ4         && $4003 == $$$Equ4         && 32 == $$$$Equ4
+
+;;; exercise parsing of label with modifiers
+MainLab:
+.local:
+    DB      'G'
+    ASSERT  $4004 == $$$@MainLab && $4004 == $$$@MainLab.local && $4004 == $$$.local
+    ASSERT  32 == $$$$@MainLab && 32 == $$$$@MainLab.local && 32 == $$$$.local
+
+;;; DEFL does what exactly? (exploring implementation, not designed)
+Defl        DEFL    $DEF1           ; page comes from value itself (36), physical address/page tracks place of definition
+    DB      'H'
+    ASSERT  $DEF1 == Defl           && 36 == $$Defl         && $4005 == $$$Defl         && 32 == $$$$Defl
+
+;;; STRUCT labels
+;;; unfortunately, the members have physical address of beginning of structure, not member itself
+;;; documenting this by test, this is not deliberate design, but accepting it right now as is
+    STRUCT S_MyStruct
+X       WORD
+Y       BYTE
+    ENDS
+
+MyS1        S_MyStruct { 0x1234, 0x56 }
+    DISP $C000, 62
+MyS2        S_MyStruct { 0x2345, 0x78 }
+    ENT
+    DB      'I'
+    ASSERT  $0003 == S_MyStruct     && 30 == $$S_MyStruct   && $4006 == $$$S_MyStruct   && 32 == $$$$S_MyStruct
+    ASSERT  $4006 == MyS1           && 32 == $$MyS1         && $4006 == $$$MyS1         && 32 == $$$$MyS1
+    ASSERT  $C000 == MyS2           && 62 == $$MyS2         && $4009 == $$$MyS2         && 32 == $$$$MyS2
+    ASSERT  $C002 == MyS2.Y         && 62 == $$MyS2.Y       && $4009 == $$$MyS2.Y       && 32 == $$$$MyS2.Y
+    ; if you need physical address of member, you can work around by using STRUCT mechanics
+    ASSERT  $400B == ($$$MyS2 + S_MyStruct.Y)
+
+;;; anything else WRT to labels??
+
+Smc+*   ld  a,123                   ; self-modify-code type of label ; physical address points to start of instruction
+    ASSERT  $400E == Smc            && 32 == $$Smc          && $400D == $$$Smc          && 32 == $$$$Smc
+
+    DEVICE NONE
+NoDevice:
+    DB      'J'
+    DISP $B000
+NoDeviceDisp:
+    DB      'K'
+    ENT
+    ASSERT  $400F == NoDevice       && 1/* no device no $$*/&& $400F == $$$NoDevice     && 0x7F00 /* LABEL_PAGE_ROM */ == $$$$NoDevice
+    ASSERT  $B000 == NoDeviceDisp                           && $4010 == $$$NoDeviceDisp && 0x7F00 /* LABEL_PAGE_ROM */ == $$$$NoDeviceDisp


### PR DESCRIPTION
Since internally these are tracked for SIZEOF implementation, it's reasonably easy to surface them to user as cross-over with already existing $$$ and $$$$ operators.

The label versions are not confined to device mode, but also the logical results come for regular labels only (for non-DISP the physical address and page is equal to regular address and page of course, inside DISP block the physical values show where the machine code landed).

For EQU/DEFL/SMC-offset labels the results are less designed and more "what happens as implementation side-effect", but they are documented by adding them to the test, so the user can actually depend on this "logic" in their own source, in case it is practical for anything.

The only really "unfortunate" behavior is struct-member-label which has physical address of the whole structure, not the member field, this is noted in test as "unfortunate" and workaround for more logical physical address of member expression suggested.

But I think I will not ever change even that, doesn't seem to be worth the extra complexity of implementation for feature which has probably no real world use case, and can be easily worked around if really needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `$$$label` and `$$$$label` operators to query physical address and page information for any label, complementing existing physical program counter operators.

* **Documentation**
  * Extended label operator documentation with usage examples and semantics for non-regular labels (EQU, DEFL, SMC-offset labels).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->