### PR TITLE
Convert SymbOS_nslookup .asm sources from ISO-8859-1 to UTF-8

### DIFF
--- a/examples/SymbOS_nslookup/src/Cmd-NsLookUp.asm
+++ b/examples/SymbOS_nslookup/src/Cmd-NsLookUp.asm
@@ -3,7 +3,7 @@
 ;@                           SymbOS network daemon                            @
 ;@                              N S L O O K U P                               @
 ;@                                                                            @
-;@               (c) 2015 by Prodatron / SymbiosiS (Jˆrn Mika)                @
+;@               (c) 2015 by Prodatron / SymbiosiS (J√∂rn Mika)                @
 ;@                                                                            @
 ;@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 
@@ -149,7 +149,7 @@ db 0
 ;==============================================================================
 
 App_BegTrns
-;### PRGPRZS -> Stack f¸r Programm-Prozess
+;### PRGPRZS -> Stack f√ºr Programm-Prozess
             ds 64
 prgstk      ds 6*2
             dw prgprz

--- a/examples/SymbOS_nslookup/src/SymbOS-Constants.asm
+++ b/examples/SymbOS_nslookup/src/SymbOS-Constants.asm
@@ -2,7 +2,7 @@
 ;@                                                                            @
 ;@                    S y m b O S   -   C o n s t a n t s                     @
 ;@                                                                            @
-;@             (c) 2000-2015 by Prodatron / SymbiosiS (Jörn Mika)             @
+;@             (c) 2000-2015 by Prodatron / SymbiosiS (JÃ¶rn Mika)             @
 ;@                                                                            @
 ;@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 


### PR DESCRIPTION
Closes #332.

`file --mime-encoding` flags two files under `examples/SymbOS_nslookup/src/`:

```
iso-8859-1 | src/Cmd-NsLookUp.asm
iso-8859-1 | src/SymbOS-Constants.asm
```

All other files in that example are already `us-ascii`. The non-ASCII bytes are 0xF6 (`ö`) and 0xFC (`ü`), used in two places:

- `;@               (c) 2015 by Prodatron / SymbiosiS (Jörn Mika)                @` (both files)
- `;### PRGPRZS -> Stack für Programm-Prozess` (Cmd-NsLookUp.asm only)

Both are inside `;` comments, so the conversion only changes comment text - not anything the Z80 assembler emits.

## Verification

- `iconv -f ISO-8859-1 -t UTF-8` on each file, then `file --mime-encoding` reports `utf-8`.
- Built sjasmplus from `master` (`make`), then ran `sjasmplus Cmd-NsLookUp-sj.asm` against the converted sources. `cmp` against the committed `nslookup.com` is byte-for-byte identical (1483 lines compiled, 0 errors, 0 warnings). The example's `#readme.txt` explicitly promises a "binary-identical nslookup.com" build, which still holds.
- Other `us-ascii` files in the example tree are unchanged.

Debian lintian's non-utf8 warning for this example should now go away.

## Test plan

- [x] file --mime-encoding examples/SymbOS_nslookup/src/*.asm => all us-ascii or utf-8, none iso-8859-1
- [x] sjasmplus examples/SymbOS_nslookup/Cmd-NsLookUp-sj.asm builds 0 errors / 0 warnings
- [x] cmp of new nslookup.com vs committed nslookup.com => identical

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Fixed character encoding in file headers and documentation comments to properly display German special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->