### PR TITLE
Ci migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,204 @@
+name: CI
+
+# GitHub Actions replacement for Cirrus CI (.cirrus.yml), which shuts down
+# 2026-06-01. Tracks upstream issue z00m128/sjasmplus#336.
+#
+# This is a faithful 1:1 port of every Cirrus task:
+#   Cirrus "Linux gcc 9/11/latest builds"  -> job: linux  (matrix)
+#   Cirrus "windows mingw build"           -> job: windows
+#   Cirrus "FreeBSD clang build"           -> job: freebsd (cross-platform-actions VM)
+#   Cirrus "MacOS default CC build"        -> job: macos
+#   Cirrus "coveralls.io coverage report"  -> job: coverage (optional upload)
+#
+# Triggers mimic Cirrus: every branch push and every pull request, skipped
+# for docs-only changes (Cirrus: skip "changesIncludeOnly('docs/*')").
+
+on:
+  push:
+    paths-ignore: ['docs/**']
+  pull_request:
+    paths-ignore: ['docs/**']
+  workflow_dispatch:
+
+# Cancel superseded runs on the same ref. GHA is slower than Cirrus was, so
+# don't pay for stale builds (addresses the speed concern raised in #336).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege for GITHUB_TOKEN. Every job here only reads code and uploads
+# build artifacts (artifact upload uses the Actions service, not this token).
+# Coveralls auth is a separate secret, not GITHUB_TOKEN. So read-only is enough,
+# and this caps the blast radius even if a third-party action is compromised.
+# (Fork PRs already get a read-only token + no secrets; this also protects
+# push/own-branch runs in case the repo default is read-write.)
+permissions:
+  contents: read
+
+jobs:
+
+  # Cirrus: container gcc:9 / gcc:11 / gcc:latest
+  #         build_script: make clean && make -j8
+  #         install_script: make install && make clean
+  #         then test_folder_tests.sh + test_folder_examples.sh
+  # PREFIX defaults to /usr/local, so `make install` puts sjasmplus on PATH
+  # inside the container; the test scripts find it via `command -v` after
+  # `make clean` removes the in-tree binary -- same as Cirrus.
+  linux:
+    name: Linux gcc ${{ matrix.gcc }}
+    runs-on: ubuntu-latest
+    container: gcc:${{ matrix.gcc }}
+    strategy:
+      fail-fast: false
+      matrix:
+        gcc: ['9', '11', 'latest']
+    steps:
+      # NOTE: gcc:9 is Debian buster (old glibc). If actions/checkout@v6's
+      # bundled Node ever fails there, drop that one matrix entry to a manual
+      # `git clone` step -- the other two cover modern toolchains.
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: gcc version
+        run: gcc --version
+      - name: Build
+        run: make clean && make -j$(nproc)
+      - name: Upload sjasmplus binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: sjasmplus-linux-gcc${{ matrix.gcc }}
+          path: sjasmplus
+          if-no-files-found: error
+      - name: Install (then clean, mirrors Cirrus)
+        run: make install && make clean
+      - name: Assemble tests
+        run: ContinuousIntegration/test_folder_tests.sh
+      - name: Assemble examples
+        run: ContinuousIntegration/test_folder_examples.sh
+
+  # Cirrus: windowsservercore:cmake, MinGW via Makefile.win
+  #         build_script: ContinuousIntegration\winbuild_mingw.bat
+  #         clean_script + version check
+  #         assemble_examples / assemble_tests bat wrappers
+  # The Cirrus image had MinGW preinstalled on PATH; GitHub's windows runner
+  # does not guarantee that, so install it explicitly. Git for Windows (bash,
+  # find, diff, cmp -- needed by the .bat/.sh scripts) is preinstalled.
+  windows:
+    name: Windows MinGW
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Set up MinGW (gcc + mingw32-make on PATH)
+        uses: egor-tensin/setup-mingw@v2
+        with:
+          platform: x64
+      - name: Build (MinGW, Makefile.win)
+        shell: cmd
+        run: ContinuousIntegration\winbuild_mingw.bat
+      - name: Upload sjasmplus.exe
+        uses: actions/upload-artifact@v7
+        with:
+          name: sjasmplus-windows-mingw
+          path: sjasmplus.exe
+          if-no-files-found: error
+      - name: Clean + version
+        shell: cmd
+        run: |
+          mingw32-make -f Makefile.win clean
+          c:\tools\sjasmplus\sjasmplus --version
+      - name: Assemble examples
+        shell: cmd
+        run: ContinuousIntegration\winbuild_mingw_examples.bat
+      - name: Assemble tests
+        shell: cmd
+        run: ContinuousIntegration\winbuild_mingw_tests.bat
+
+  # Cirrus: freebsd_instance freebsd-15-0, clang, with unit tests.
+  # ped7g flagged cross-platform-actions in #336 -- using it here.
+  # Cirrus used 15.0; cross-platform-actions tracks released images, so this
+  # pins a stable release. Bump `version` when a newer image is available.
+  freebsd:
+    name: FreeBSD clang
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Build + unit tests (FreeBSD VM)
+        uses: cross-platform-actions/action@v0.27.0
+        with:
+          operating_system: freebsd
+          version: '14.2'
+          shell: bash
+          run: |
+            # Cirrus: pkg update -f && pkg install -y gmake bash diffutils
+            sudo IGNORE_OSVERSION=yes pkg update -f
+            sudo pkg install -y gmake bash diffutils
+            bash --version  || echo "no bash"
+            gmake --version || echo "no gmake"
+            cc --version    || echo "no cc"
+            c++ --version   || echo "no c++"
+            # FreeBSD make can't handle the Makefile -> use gmake, as Cirrus did
+            gmake clean && gmake -j4 CC=cc CXX=c++
+            gmake clean && gmake -j4 CC=cc CXX=c++ tests
+
+  # Cirrus: macos_instance, default CC, with unit tests.
+  macos:
+    name: macOS clang
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Tool versions
+        run: |
+          git --version || echo "no git"
+          bash --version || echo "no bash"
+          make --version || echo "no make"
+          cc --version || echo "no cc"
+          c++ --version || echo "no c++"
+          date
+          sysctl -n hw.physicalcpu
+      - name: Build
+        run: make clean && make -j$(sysctl -n hw.logicalcpu) CC=cc CXX=c++
+      - name: Upload sjasmplus binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: sjasmplus-macos
+          path: sjasmplus
+          if-no-files-found: error
+      - name: Unit tests
+        run: make clean && make -j$(sysctl -n hw.logicalcpu) CC=cc CXX=c++ tests
+
+  # Cirrus: coveralls.io pipe (gcc:14, DEBUG=1, make coverage).
+  # The Cirrus version was hard-gated to z00m128's repo + encrypted token and
+  # skipped on PRs. Here the coverage *build+tests* always run (extra signal,
+  # mirrors the Cirrus gcc14 compile); the Coveralls upload is opt-in: it only
+  # fires off PRs when a COVERALLS_REPO_TOKEN repo secret exists, and never
+  # breaks the build.
+  coverage:
+    name: Coverage (gcc14)
+    runs-on: ubuntu-latest
+    container: gcc:14
+    needs: [macos]   # mirrors Cirrus `depends_on: macos`
+    env:
+      DEBUG: 1
+      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 0   # Cirrus used full clone for the git revision number
+      - name: Build coverage (runs full test suite via `make coverage`)
+        run: make clean && make -j$(nproc) coverage
+      - name: Upload to Coveralls
+        if: ${{ env.COVERALLS_REPO_TOKEN != '' && github.event_name != 'pull_request' }}
+        continue-on-error: true
+        run: |
+          apt-get update && apt-get install -y python3-pip git
+          pip3 install --break-system-packages \
+            git+https://github.com/ped7g/cpp-coveralls.git@master
+          CI_SERVICE_NAME=github-actions \
+          cpp-coveralls -n -e lua5.5/ -e LuaBridge/ -e unittest-cpp/ -e cpp-src-tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,10 +90,23 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - name: Set up MinGW (gcc + mingw32-make on PATH)
-        uses: egor-tensin/setup-mingw@v2
-        with:
-          platform: x64
+      # GitHub's windows runner ships MinGW via Chocolatey but not on PATH.
+      # Don't use egor-tensin/setup-mingw: its static workaround crashes on the
+      # current choco mingw layout (missing libpthread.dll.a). Instead expose
+      # mingw + GNU tools exactly where the Cirrus windowsservercore image had
+      # them: the choco mingw bin + Git's usr\bin (bash/find/diff/cmp).
+      - name: Set up MinGW + GNU tools on PATH
+        shell: pwsh
+        run: |
+          choco install mingw -y --no-progress
+          Add-Content $env:GITHUB_PATH 'C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin'
+          Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\usr\bin'
+      - name: Tool versions (mingw + GNU)
+        shell: cmd
+        run: |
+          where mingw32-make && mingw32-make --version
+          where gcc && gcc --version
+          where bash && bash --version
       - name: Build (MinGW, Makefile.win)
         shell: cmd
         run: ContinuousIntegration\winbuild_mingw.bat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,17 @@ jobs:
             c++ --version   || echo "no c++"
             # FreeBSD make can't handle the Makefile -> use gmake, as Cirrus did
             gmake clean && gmake -j4 CC=cc CXX=c++
+            # Cirrus captured the binary between build and test; the next
+            # `gmake clean` removes it, so copy it aside (sync_files=true
+            # syncs this back to the host for upload-artifact below).
+            cp sjasmplus sjasmplus.freebsd
             gmake clean && gmake -j4 CC=cc CXX=c++ tests
+      - name: Upload sjasmplus binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: sjasmplus-freebsd
+          path: sjasmplus.freebsd
+          if-no-files-found: error
 
   # Cirrus: macos_instance, default CC, with unit tests.
   macos:
@@ -209,7 +219,9 @@ jobs:
     needs: [macos]   # mirrors Cirrus `depends_on: macos`
     env:
       DEBUG: 1
-      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      # Boolean gate only -- the secret value is exposed solely to the upload
+      # step below, never to `make coverage` (which builds + runs the suite).
+      COVERALLS_ENABLED: ${{ secrets.COVERALLS_REPO_TOKEN != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
@@ -218,8 +230,10 @@ jobs:
       - name: Build coverage (runs full test suite via `make coverage`)
         run: make clean && make -j$(nproc) coverage
       - name: Upload to Coveralls
-        if: ${{ env.COVERALLS_REPO_TOKEN != '' && github.event_name != 'pull_request' }}
+        if: ${{ env.COVERALLS_ENABLED == 'true' && github.event_name != 'pull_request' }}
         continue-on-error: true
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
           apt-get update && apt-get install -y python3-pip git
           pip3 install --break-system-packages \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,17 @@ name: CI
 #
 # Triggers mimic Cirrus: every branch push and every pull request, skipped
 # for docs-only changes (Cirrus: skip "changesIncludeOnly('docs/*')").
+#
+# Supply-chain hardening: every external action is pinned to a full commit
+# SHA, not a moving tag (a tag like @v6 can be silently repointed at malicious
+# code). The trailing "# vX" comment is the human-readable version that SHA
+# resolves to -- bump the SHA and the comment together (Dependabot can do
+# this). SHAs resolved 2026-05-17:
+#   actions/checkout            v6     -> de0fac2e4500dabe0009e67214ff5f5447ce83dd
+#   actions/upload-artifact     v7     -> 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+#   cross-platform-actions      v1.0.0 -> 233156312992f3f169d8d0c633c21d12a5d30455
+# (cross-platform-actions bumped v0.27.0 -> v1.0.0: v0.27.0 ran on Node 20,
+#  which GitHub force-deprecates 2026-06-02; v1.0.0 is Node 24.)
 
 on:
   push:
@@ -56,7 +67,7 @@ jobs:
       # NOTE: gcc:9 is Debian buster (old glibc). If actions/checkout@v6's
       # bundled Node ever fails there, drop that one matrix entry to a manual
       # `git clone` step -- the other two cover modern toolchains.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           submodules: recursive
       - name: gcc version
@@ -64,7 +75,7 @@ jobs:
       - name: Build
         run: make clean && make -j$(nproc)
       - name: Upload sjasmplus binary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: sjasmplus-linux-gcc${{ matrix.gcc }}
           path: sjasmplus
@@ -87,7 +98,7 @@ jobs:
     name: Windows MinGW
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           submodules: recursive
       # GitHub's windows runner ships MinGW via Chocolatey but not on PATH.
@@ -111,7 +122,7 @@ jobs:
         shell: cmd
         run: ContinuousIntegration\winbuild_mingw.bat
       - name: Upload sjasmplus.exe
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: sjasmplus-windows-mingw
           path: sjasmplus.exe
@@ -136,11 +147,11 @@ jobs:
     name: FreeBSD clang
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           submodules: recursive
       - name: Build + unit tests (FreeBSD VM)
-        uses: cross-platform-actions/action@v0.27.0
+        uses: cross-platform-actions/action@233156312992f3f169d8d0c633c21d12a5d30455  # v1.0.0
         with:
           operating_system: freebsd
           version: '14.2'
@@ -162,7 +173,7 @@ jobs:
     name: macOS clang
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           submodules: recursive
       - name: Tool versions
@@ -177,7 +188,7 @@ jobs:
       - name: Build
         run: make clean && make -j$(sysctl -n hw.logicalcpu) CC=cc CXX=c++
       - name: Upload sjasmplus binary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: sjasmplus-macos
           path: sjasmplus
@@ -200,7 +211,7 @@ jobs:
       DEBUG: 1
       COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           submodules: recursive
           fetch-depth: 0   # Cirrus used full clone for the git revision number


### PR DESCRIPTION
Dear Ped, never say I don't do nice things for you <3

"Let me give it to Claude for you" Complete — CI migration done and verified
The full Cirrus → GitHub Actions migration is finished and green on your fork. Final state:

Verified working (run 25990378812, all 7 jobs ✓):

Linux gcc 9 / 11 / latest · Windows MinGW · FreeBSD clang · macOS clang · Coverage (gcc14)
Artifacts published for every build platform
Node 20 deprecation cleared (cross-platform-actions now v1.0.0 / Node 24)
Hardened:

All 9 external-action refs SHA-pinned with # vX comments; pin policy + SHA→version map + resolution date documented in the ci.yml header (Dependabot-compatible format)
Read-only GITHUB_TOKEN, fork-PR runs gated on maintainer approval, no secrets to fork PRs, least-privilege permissions:

.cirrus.yml not retired (still in place; Cirrus stops 2026-06-01)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Continuous integration now runs on GitHub Actions with automated builds and testing across multiple platforms: Linux (various GCC versions), Windows, FreeBSD, and macOS.
  * Added automated code coverage analysis and reporting.
  * Improved workflow reliability with concurrency management and pinned external dependency versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/z00m128/sjasmplus/pull/337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->