### PR TITLE
Stop BLOCK/DS truncating current address to 16b, close #390

### DIFF
--- a/docs/documentation.xml
+++ b/docs/documentation.xml
@@ -206,6 +206,16 @@
       <para><variablelist>
 
 <varlistentry>
+            <term>? - 1.24.1?</term>
+            <listitem>
+              <synopsis>
+- stop `BLOCK`/`DS` truncating `$` (aka program counter) to 16 bit address space + new test
+- minor changes in examples, docs and expression parser implementation
+</synopsis>
+            </listitem>
+          </varlistentry>
+
+<varlistentry>
             <term>26.8.2026 - 1.24.0</term>
             <listitem>
               <synopsis>

--- a/sjasm/devices.cpp
+++ b/sjasm/devices.cpp
@@ -383,36 +383,38 @@ void CDevice::CheckPage(const ECheckPageLevel level) {
 		CurAddress &= 0xFFFF;
 	}
 	// check the emit address for bytecode
-	const int realAddr = DISP_NONE != PseudoORG ? adrdisp : CurAddress;
+	const int longAddr = DISP_NONE != PseudoORG ? adrdisp : CurAddress;
 	// quicker check to avoid scanning whole slots array every byte
 	if (CHECK_RESET != level
-		&& Slots[previousSlotI]->Address <= realAddr
-		&& realAddr < Slots[previousSlotI]->Address + Slots[previousSlotI]->Size) {
+		&& Slots[previousSlotI]->Address <= longAddr
+		&& longAddr < Slots[previousSlotI]->Address + Slots[previousSlotI]->Size) {
 		// refresh MemoryPointer in case the CurAddress did move a bit without emit (negative BLOCK, etc)
-		MemoryPointer = Slots[previousSlotI]->Page->RAM + (realAddr - Slots[previousSlotI]->Address);
+		MemoryPointer = Slots[previousSlotI]->Page->RAM + (longAddr - Slots[previousSlotI]->Address);
 		assert(	(Slots[previousSlotI]->Page->RAM <= MemoryPointer) &&
 				(MemoryPointer < Slots[previousSlotI]->Page->RAM + Slots[previousSlotI]->Size));
 		return;
 	}
 	for (int i=SlotsCount; i--; ) {
 		CDeviceSlot* const S = Slots[i];
-		if (realAddr < S->Address) continue;
+		if ((longAddr & 0xFFFF) < S->Address) continue;		// find slot after masking long address against CPU address space
 		Page = S->Page;
-		MemoryPointer = Page->RAM + (realAddr - S->Address);
- 		if (CHECK_RESET == level) {
+		MemoryPointer =
+						(S->Address <= longAddr && longAddr < S->Address + S->Size) ?
+							Page->RAM + (longAddr - S->Address) :
+							nullptr;
+		if (CHECK_RESET == level) {
 			previousSlotOpt = S->Option;
 			previousSlotI = i;
 			limitExceeded = false;
 			return;
 		}
 		// if still in the same slot and within boundaries, we are done
-		if (i == previousSlotI && realAddr < S->Address + S->Size) return;
+		if (i == previousSlotI && S->Address <= longAddr && longAddr < S->Address + S->Size) return;
 		// crossing into other slot, check options for special functionality of old slot
-		if (S->Address + S->Size <= realAddr) MemoryPointer = nullptr; // you're not writing there
 		switch (previousSlotOpt) {
 			case CDeviceSlot::O_ERROR:
 				if (LASTPASS == pass && CHECK_EMIT == level && !limitExceeded) {
-					ErrorInt("Write outside of memory slot", realAddr, SUPPRESS);
+					ErrorInt("Write outside of memory slot", longAddr, SUPPRESS);
 					limitExceeded = true;
 				}
 				break;
@@ -437,9 +439,9 @@ void CDevice::CheckPage(const ECheckPageLevel level) {
 					previousSlotOpt = S->Option;
 					break;		// continue into next slot, don't wrap any more
 				}
-				if (realAddr != (prevS->Address + prevS->Size)) {	// should be equal
+				if (longAddr != (prevS->Address + prevS->Size)) {	// should be equal
 					ErrorInt("Write beyond memory slot in wrap-around slot caught too late by",
-								realAddr - prevS->Address - prevS->Size, FATAL);
+								longAddr - prevS->Address - prevS->Size, FATAL);
 					break;
 				}
 				prevS->Page = Pages[nextPageN];		// map next page into the guarded slot
@@ -451,8 +453,9 @@ void CDevice::CheckPage(const ECheckPageLevel level) {
 			}
 			default:
 				if (LASTPASS == pass && CHECK_EMIT == level && !limitExceeded && !MemoryPointer) {
-					ErrorInt("Write outside of device memory at", realAddr, SUPPRESS);
+					ErrorInt("Write outside of device memory at", longAddr, SUPPRESS);
 					limitExceeded = true;
+					previousSlotI = i;				// in this case change of slot should NOT clear the just set `limitExceeded`
 				}
 				break;
 		}

--- a/sjasm/sjio.cpp
+++ b/sjasm/sjio.cpp
@@ -509,9 +509,8 @@ void EmitWords(const int* words, bool isInstructionStart) {
 
 void EmitBlock(aint byte, aint len, bool preserveDeviceMemory, int emitMaxToListing) {
 	if (len <= 0) {
-		const aint adrMask = Options::IsLongPtr ? ~0 : 0xFFFF;
-		CurAddress = (CurAddress + len) & adrMask;
-		if (DISP_NONE != PseudoORG) adrdisp = (adrdisp + len) & adrMask;
+		CurAddress += len;
+		if (DISP_NONE != PseudoORG) adrdisp += len;
 		if (DeviceID)	Device->CheckPage(CDevice::CHECK_NO_EMIT);
 		else			CheckRamLimitExceeded();
 		return;
@@ -581,8 +580,8 @@ void BinIncFile(fullpath_ref_t file, aint offset, aint length) {
 			}
 			length -= advanceLength;
 			if (length <= 0 && 0 == advanceLength) Error("BinIncFile internal error", NULL, FATAL);
-			if (DISP_NONE != PseudoORG) adrdisp = adrdisp + advanceLength;
-			CurAddress = CurAddress + advanceLength;
+			CurAddress += advanceLength;
+			if (DISP_NONE != PseudoORG) adrdisp += advanceLength;
 		}
 	} else {
 		// Seek to the beginning of part to include

--- a/tests/devices/longptr/Issue390_2_mmu_next.asm
+++ b/tests/devices/longptr/Issue390_2_mmu_next.asm
@@ -1,0 +1,11 @@
+; verify behavior of going "back" in MMU "next" auto-wrap mode ends with some error
+    DEVICE ZXSPECTRUMNEXT
+    MMU $8000 n, 21, $8000      ; select slot with "next auto-wrap" feature
+    ld a,7
+    DS -2                       ; go backward to start of current slot (arguably "valid" state)
+    ASSERT $8000 == $
+    res 4,(ix+5),l              ; so this one should work
+    DS -5                       ; go backward and leak outside of current slot
+    ; it's edge case, not expected to be ever used by end user, so just verify sjasmplus
+    ; is going down in flames in somewhat reasonable way, like currently with fatal error (but not a random crash)
+    res 4,(ix+5),l              ; oopsie here

--- a/tests/devices/longptr/Issue390_2_mmu_next.lst
+++ b/tests/devices/longptr/Issue390_2_mmu_next.lst
@@ -1,0 +1,1 @@
+Issue390_2_mmu_next.asm(8): error: Write beyond memory slot in wrap-around slot caught too late by: -8193

--- a/tests/devices/longptr/Issue390_device_address_space_masking.asm
+++ b/tests/devices/longptr/Issue390_device_address_space_masking.asm
@@ -1,0 +1,74 @@
+; the user issue was detecting overflow of code/data in individual bank/section
+; work around idea was to modify --longptr in DEVICE mode to keep `$` 24 bit addressable
+; it turned out that is what is happening already without --longptr, so
+; `$` can be checked to see how far the assembling went, except some directives
+; hard-mask the `$` to 16bit
+
+; this test is to find such directives/situations and ensure they
+; do NOT modify `$` itself, but just mask its value to device address space
+
+; directives still truncating `$` to 16b (currently intentionally):
+;   - ORG (and various built-in ORG calls) (--longptr enables large address)
+;   - MMU (even without optional ORG argument!)
+;   - DISP block auto-wraps the displaced address (0xFFFF advances to 0x0000) (--longptr enables also large displaced address)
+
+    DEVICE NOSLOT64K
+
+    ORG 0x100
+    DS 60000,0
+    ASSERT 60000 + 0x100 == $
+
+; produce error about write outside of device memory at: 65536
+; this is intended and wanted behavior, the leak of device address space is error
+    DS 60000,0
+    ASSERT 2 * 60000 + 0x100 == $   ; but the `$` should keep the large address
+; only one error per one leak, so second 60k block just advances `$` further
+    DS 60000,0
+    ASSERT 3 * 60000 + 0x100 == $
+    DS 1
+    ASSERT 1 + 3 * 60000 + 0x100 == $
+; before fix `DS 1,0` did truncate the address from 0x2'C020 to 0xC021 (-0x2'0000)
+    DS 1,0
+    ASSERT 2 + 3 * 60000 + 0x100 == $
+    DS 2,0
+    ASSERT 4 + 3 * 60000 + 0x100 == $
+
+    ORG 65535
+    res 4,(ix+5),l  ; new error ; long bytecode instruction
+    ASSERT 0x1'0003 == $
+    ld a,7
+    ASSERT 0x1'0005 == $
+
+    ORG 65535
+    ld (ix+123),bc  ; new error ; fake instruction composed of two long instructions
+    ASSERT 0x1'0005 == $
+    ld a,7
+    ASSERT 0x1'0007 == $
+    ; verify memory content, FFFF is overwriten by `ld` fake instruction,
+    ; but wrap-around in listing to 0000+ is NOT real, the machine code is just LOST
+    ; after error about writing outside of device. This is intended at this moment.
+    ; (DISP *has* wrap-around on the displaced address)
+    ASSERT $DD == {b $FFFF} && $0000 == {$0000} && $0000 == {$0005}
+
+    ORG 0
+    ld a,7
+    ASSERT $3E == {b $0000}
+    DS -5           ; warns about negative block size
+    res 4,(ix+5),l  ; new error ; write outside of device memory should be detected also here
+    ASSERT +2-5+4 == $
+    ; verify memory content, end of RAM is intact by `res`, but $0000 becomes $A5 (last byte of opcode), 07 is from previous `ld a,7`
+    ASSERT $DD00 == {$FFFE} && $07A5 == {$0000}
+
+; non-device assembling mode
+    DEVICE NONE
+    ORG 65535
+    res 4,(ix+5),l  ; just warning about RAM-limit exceeded in non-device mode
+    ASSERT 0x1'0003 == $
+    ld a,7
+    ASSERT 0x1'0005 == $
+
+    ORG 0x100
+    DS 0x1'0000,0xAA        ; warning
+    ASSERT 0x1'0100 == $
+    DS 1, 0
+    ASSERT 0x1'0101 == $    ; the `$` should retain large address

--- a/tests/devices/longptr/Issue390_device_address_space_masking.lst
+++ b/tests/devices/longptr/Issue390_device_address_space_masking.lst
@@ -1,0 +1,88 @@
+# file opened: Issue390_device_address_space_masking.asm
+ 1    0000              ; the user issue was detecting overflow of code/data in individual bank/section
+ 2    0000              ; work around idea was to modify --longptr in DEVICE mode to keep `$` 24 bit addressable
+ 3    0000              ; it turned out that is what is happening already without --longptr, so
+ 4    0000              ; `$` can be checked to see how far the assembling went, except some directives
+ 5    0000              ; hard-mask the `$` to 16bit
+ 6    0000
+ 7    0000              ; this test is to find such directives/situations and ensure they
+ 8    0000              ; do NOT modify `$` itself, but just mask its value to device address space
+ 9    0000
+10    0000              ; directives still truncating `$` to 16b (currently intentionally):
+11    0000              ;   - ORG (and various built-in ORG calls) (--longptr enables large address)
+12    0000              ;   - MMU (even without optional ORG argument!)
+13    0000              ;   - DISP block auto-wraps the displaced address (0xFFFF advances to 0x0000) (--longptr enables also large displaced address)
+14    0000
+15    0000                  DEVICE NOSLOT64K
+16    0000
+17    0000                  ORG 0x100
+18    0100 00 00 00...      DS 60000,0
+19    EB60                  ASSERT 60000 + 0x100 == $
+20    EB60
+21    EB60              ; produce error about write outside of device memory at: 65536
+22    EB60              ; this is intended and wanted behavior, the leak of device address space is error
+Issue390_device_address_space_masking.asm(23): error: Write outside of device memory at: 65536
+23    EB60 00 00 00...      DS 60000,0
+24    D5C0                  ASSERT 2 * 60000 + 0x100 == $   ; but the `$` should keep the large address
+25    D5C0              ; only one error per one leak, so second 60k block just advances `$` further
+26    D5C0 00 00 00...      DS 60000,0
+27    C020                  ASSERT 3 * 60000 + 0x100 == $
+28    C020 00               DS 1
+29    C021                  ASSERT 1 + 3 * 60000 + 0x100 == $
+30    C021              ; before fix `DS 1,0` did truncate the address from 0x2'C020 to 0xC021 (-0x2'0000)
+31    C021 00               DS 1,0
+32    C022                  ASSERT 2 + 3 * 60000 + 0x100 == $
+33    C022 00 00            DS 2,0
+34    C024                  ASSERT 4 + 3 * 60000 + 0x100 == $
+35    C024
+36    C024                  ORG 65535
+Issue390_device_address_space_masking.asm(37): error: Write outside of device memory at: 65536
+37    FFFF DD CB 05 A5      res 4,(ix+5),l  ; new error ; long bytecode instruction
+38    0003                  ASSERT 0x1'0003 == $
+39    0003 3E 07            ld a,7
+40    0005                  ASSERT 0x1'0005 == $
+41    0005
+42    0005                  ORG 65535
+Issue390_device_address_space_masking.asm(43): error: Write outside of device memory at: 65536
+43    FFFF DD 71 7B DD      ld (ix+123),bc  ; new error ; fake instruction composed of two long instructions
+43    0003 70 7C
+44    0005                  ASSERT 0x1'0005 == $
+45    0005 3E 07            ld a,7
+46    0007                  ASSERT 0x1'0007 == $
+47    0007                  ; verify memory content, FFFF is overwriten by `ld` fake instruction,
+48    0007                  ; but wrap-around in listing to 0000+ is NOT real, the machine code is just LOST
+49    0007                  ; after error about writing outside of device. This is intended at this moment.
+50    0007                  ; (DISP *has* wrap-around on the displaced address)
+51    0007                  ASSERT $DD == {b $FFFF} && $0000 == {$0000} && $0000 == {$0005}
+52    0007
+53    0007                  ORG 0
+54    0000 3E 07            ld a,7
+55    0002                  ASSERT $3E == {b $0000}
+Issue390_device_address_space_masking.asm(56): warning: Negative BLOCK moves PC backwards
+56    0002                  DS -5           ; warns about negative block size
+Issue390_device_address_space_masking.asm(57): error: Write outside of device memory at: -3
+57    FFFD DD CB 05 A5      res 4,(ix+5),l  ; new error ; write outside of device memory should be detected also here
+58    0001                  ASSERT +2-5+4 == $
+59    0001                  ; verify memory content, end of RAM is intact by `res`, but $0000 becomes $A5 (last byte of opcode), 07 is from previous `ld a,7`
+60    0001                  ASSERT $DD00 == {$FFFE} && $07A5 == {$0000}
+61    0001
+62    0001              ; non-device assembling mode
+63    0001                  DEVICE NONE
+64    0001                  ORG 65535
+Issue390_device_address_space_masking.asm(65): warning: RAM limit exceeded 0x10000 by ORG
+65    FFFF DD CB 05 A5      res 4,(ix+5),l  ; just warning about RAM-limit exceeded in non-device mode
+66    0003                  ASSERT 0x1'0003 == $
+67    0003 3E 07            ld a,7
+68    0005                  ASSERT 0x1'0005 == $
+69    0005
+70    0005                  ORG 0x100
+Issue390_device_address_space_masking.asm(71): warning: RAM limit exceeded 0x10000 by ORG
+71    0100 AA AA AA...      DS 0x1'0000,0xAA        ; warning
+72    0100                  ASSERT 0x1'0100 == $
+73    0100 00               DS 1, 0
+74    0101                  ASSERT 0x1'0101 == $    ; the `$` should retain large address
+75    0101
+# file closed: Issue390_device_address_space_masking.asm
+
+Value    Label
+------ - -----------------------------------------------------------


### PR DESCRIPTION
Modify BLOCK aka DS to not truncate the current address in specific use cases, also make Device::CheckPage more robust and report also negative address (can be achieved by negative-size block).

So now except ORG/MMU and DISP auto-wrap the current address should be stable and it can move outside of CPU address space (and such leak should be correctly reported in DEVICE mode).

Background story time:

The user issue was detecting overflow of code/data in individual bank/section.

Work around idea was to modify --longptr in DEVICE mode to keep `$` 24 bit addressable, it turned out that is what is already happening even without --longptr, so `$` can be checked to see how far the assembling went.

Except some directives (DS aka BLOCK) hard-masked the `$` to 16bit in some scenarios.

Directives still truncating `$` to 16b (currently intentionally):
- ORG (and various built-in ORG calls) (--longptr enables large address)
 - MMU (even without optional ORG argument)
- DISP block auto-wraps the displaced address (0xFFFF advances to 0x0000) (--longptr enables large displaced address)

User still needs valid "program counter" `$` to affect virtual device memory, when the source leaks outside of device memory, the further machine code produced to invalid addresses is just discarded (first one will cause error report, rest of it goes silently).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Address tracking now preserves full assembled addresses during oversized data reservations and file inclusions instead of truncating them to 16 bits.
  * Device address checks correctly handle 16-bit masking, slot boundaries, wraparound, and out-of-range writes.
  * Improved diagnostics for writes outside device memory, negative-size reservations, and invalid backward movement in wraparound slots.

* **Documentation**
  * Updated the changelog with address-handling corrections and related examples, documentation, and expression-parser updates.

* **Tests**
  * Added regression coverage for large addresses, device boundaries, long instructions, origin changes, and reservation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->